### PR TITLE
fix(ark): subtract full epoch during timestamp calculation

### DIFF
--- a/packages/ark/source/client.service.test.ts
+++ b/packages/ark/source/client.service.test.ts
@@ -126,8 +126,8 @@ describe("ClientService", async ({ assert, nock, beforeAll, it, loader }) => {
 			.get("/api/transactions")
 			.query({
 				address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8",
-				"timestamp.from": 119401200,
-				"timestamp.to": 150937200,
+				"timestamp.from": 119354400,
+				"timestamp.to": 150890400,
 				type: 0,
 				typeGroup: 1,
 			})

--- a/packages/ark/source/client.service.ts
+++ b/packages/ark/source/client.service.ts
@@ -294,7 +294,7 @@ export class ClientService extends Services.AbstractClientService {
 
 				if (epoch) {
 					for (const [key, value] of Object.entries(normalized)) {
-						normalized[key] = value - DateTime.make(epoch).startOf("day").toUNIX();
+						normalized[key] = value - DateTime.make(epoch).toUNIX();
 					}
 				}
 


### PR DESCRIPTION
FIxes the timestamp calculation for the api request.