### PR TITLE
refactor(ark): never build api requests with timestamps smaller than zero

### DIFF
--- a/packages/ark/source/client.service.ts
+++ b/packages/ark/source/client.service.ts
@@ -294,7 +294,7 @@ export class ClientService extends Services.AbstractClientService {
 
 				if (epoch) {
 					for (const [key, value] of Object.entries(normalized)) {
-						normalized[key] = value - DateTime.make(epoch).toUNIX();
+						normalized[key] = Math.max(value - DateTime.make(epoch).toUNIX(), 0);
 					}
 				}
 


### PR DESCRIPTION
Adds a little safeguard to the timestamp calculation, so that negative values are never passed to the api, which would otherwise result in the node to return an error response (422).