### PR TITLE
refactor(ark): use api response to decide if network is legacy

### DIFF
--- a/packages/ark/source/client.service.test.ts
+++ b/packages/ark/source/client.service.test.ts
@@ -7,8 +7,8 @@ import { SignedTransactionData } from "./signed-transaction.dto.js";
 import { ConfirmedTransactionData } from "./confirmed-transaction.dto.js";
 import { WalletData } from "./wallet.dto.js";
 
-describe("ClientService", async ({ assert, nock, beforeAll, it, loader }) => {
-	beforeAll(async (context) => {
+describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
+	beforeEach(async (context) => {
 		context.subject = await createService(ClientService, undefined, (container) => {
 			container.constant(IoC.BindingType.Container, container);
 			container.constant(IoC.BindingType.DataTransferObjects, {
@@ -34,8 +34,10 @@ describe("ClientService", async ({ assert, nock, beforeAll, it, loader }) => {
 
 	it("should retrieve a list of transactions for a single address via Core 2.0", async (context) => {
 		nock.fake(/.+/)
-			.get("/api/transactions")
-			.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8", page: "0" })
+			.post("/api/wallets/search", { limit: 1 })
+			.reply(200, {})
+			.post("/api/transactions/search", { addresses: ["DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8"] })
+			.query({ page: "0" })
 			.reply(200, loader.json(`test/fixtures/client/transactions.json`));
 
 		const result = await context.subject.transactions({
@@ -49,11 +51,10 @@ describe("ClientService", async ({ assert, nock, beforeAll, it, loader }) => {
 
 	it("should retrieve a list of transactions for multiple addresses via Core 2.0", async (context) => {
 		nock.fake(/.+/)
-			.get("/api/transactions")
-			.query({
-				page: "0",
-				address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8,DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5",
-			})
+			.post("/api/wallets/search", { limit: 1 })
+			.reply(200, {})
+			.post("/api/transactions/search", { addresses: ["DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8", "DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5"] })
+			.query({ page: "0" })
 			.reply(200, loader.json(`test/fixtures/client/transactions.json`));
 
 		const result = await context.subject.transactions({
@@ -70,6 +71,12 @@ describe("ClientService", async ({ assert, nock, beforeAll, it, loader }) => {
 
 	it("should retrieve a list of transactions for a single address via Core 3.0", async (context) => {
 		nock.fake(/.+/)
+			.post("/api/wallets/search", { limit: 1 })
+			.reply(404, {
+				error: "RequestException",
+				message: "HTTP request returned status code 404",
+				statusCode: 404,
+			})
 			.get("/api/transactions")
 			.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8" })
 			.reply(200, loader.json(`test/fixtures/client/transactions.json`));
@@ -84,6 +91,12 @@ describe("ClientService", async ({ assert, nock, beforeAll, it, loader }) => {
 
 	it("should retrieve a list of transactions for multiple addresses via Core 3.0", async (context) => {
 		nock.fake(/.+/)
+			.post("/api/wallets/search", { limit: 1 })
+			.reply(404, {
+				error: "RequestException",
+				message: "HTTP request returned status code 404",
+				statusCode: 404,
+			})
 			.get("/api/transactions")
 			.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8,DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5" })
 			.reply(200, loader.json(`test/fixtures/client/transactions.json`));
@@ -101,6 +114,12 @@ describe("ClientService", async ({ assert, nock, beforeAll, it, loader }) => {
 
 	it("should retrieve a list of transactions for an advanced search via Core 3.0", async (context) => {
 		nock.fake(/.+/)
+			.post("/api/wallets/search", { limit: 1 })
+			.reply(404, {
+				error: "RequestException",
+				message: "HTTP request returned status code 404",
+				statusCode: 404,
+			})
 			.get("/api/transactions")
 			.query({
 				address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8",
@@ -123,6 +142,12 @@ describe("ClientService", async ({ assert, nock, beforeAll, it, loader }) => {
 
 	it("should retrieve a list of transactions for an advanced search including timestamp via Core 3.0", async (context) => {
 		nock.fake(/.+/)
+			.post("/api/wallets/search", { limit: 1 })
+			.reply(404, {
+				error: "RequestException",
+				message: "HTTP request returned status code 404",
+				statusCode: 404,
+			})
 			.get("/api/transactions")
 			.query({
 				address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8",
@@ -168,8 +193,9 @@ describe("ClientService", async ({ assert, nock, beforeAll, it, loader }) => {
 		});
 
 		nock.fake(/.+/)
-			.get("/api/wallets")
-			.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8" })
+			.post("/api/wallets/search", { limit: 1 })
+			.reply(200, {})
+			.post("/api/wallets/search", { addresses: ["DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8"] })
 			.reply(200, loader.json(`test/fixtures/client/wallets.json`));
 
 		const result = await context.subject.wallets({
@@ -192,6 +218,12 @@ describe("ClientService", async ({ assert, nock, beforeAll, it, loader }) => {
 		});
 
 		nock.fake(/.+/)
+			.post("/api/wallets/search", { limit: 1 })
+			.reply(404, {
+				error: "RequestException",
+				message: "HTTP request returned status code 404",
+				statusCode: 404,
+			})
 			.get("/api/wallets")
 			.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8" })
 			.reply(200, loader.json(`test/fixtures/client/wallets.json`));

--- a/packages/ark/source/client.service.test.ts
+++ b/packages/ark/source/client.service.test.ts
@@ -53,7 +53,9 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 		nock.fake(/.+/)
 			.post("/api/wallets/search", { limit: 1 })
 			.reply(200, {})
-			.post("/api/transactions/search", { addresses: ["DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8", "DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5"] })
+			.post("/api/transactions/search", {
+				addresses: ["DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8", "DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5"],
+			})
 			.query({ page: "0" })
 			.reply(200, loader.json(`test/fixtures/client/transactions.json`));
 

--- a/packages/ark/source/ledger.service.test.ts
+++ b/packages/ark/source/ledger.service.test.ts
@@ -96,13 +96,17 @@ describe("LedgerService - scan", ({ assert, nock, beforeAll, it, loader, stub })
 
 	it("should scan for legacy wallets", async () => {
 		nock.fake(/.+/)
-			.get(
-				"/api/wallets?address=D9xJncW4ECUSJQWeLP7wncxhDTvNeg2HNK%2CDFgggtreMXQNQKnxHddvkaPHcQbRdK3jyJ%2CDFr1CR81idSmfgQ19KXe4M6keqUEAuU8kF%2CDTYiNbvTKveMtJC8KPPdBrgRWxfPxGp1WV%2CDJyGFrZv4MYKrTMcjzEyhZzdTAJju2Rcjr",
-			)
+			.post("/api/wallets/search", { limit: 1 })
+			.reply(404, {
+				error: "RequestException",
+				message: "HTTP request returned status code 404",
+				statusCode: 404,
+			})
+			.get("/api/wallets")
+			.query({ address: "D9xJncW4ECUSJQWeLP7wncxhDTvNeg2HNK,DFgggtreMXQNQKnxHddvkaPHcQbRdK3jyJ,DFr1CR81idSmfgQ19KXe4M6keqUEAuU8kF,DTYiNbvTKveMtJC8KPPdBrgRWxfPxGp1WV,DJyGFrZv4MYKrTMcjzEyhZzdTAJju2Rcjr" })
 			.reply(200, loader.json(`test/fixtures/client/wallets-page-0.json`))
-			.get(
-				"/api/wallets?address=DHnV81YdhYDkwCLD8pkxiXh53pGFw435GS%2CDGhLzafzQpBYjDAWP41U4cx5CKZ5BdSnS3%2CDLVXZyKFxLLdyuEtJRUvFoKcorSrnBnq48%2CDFZAfJ1i1LsvhkUk76Piw4v7oTgq12pX9Z%2CDGfNF9bGPss6YKLEqK5gwr4C1M7vgfenzn",
-			)
+			.get("/api/wallets")
+			.query({ address: "DHnV81YdhYDkwCLD8pkxiXh53pGFw435GS,DGhLzafzQpBYjDAWP41U4cx5CKZ5BdSnS3,DLVXZyKFxLLdyuEtJRUvFoKcorSrnBnq48,DFZAfJ1i1LsvhkUk76Piw4v7oTgq12pX9Z,DGfNF9bGPss6YKLEqK5gwr4C1M7vgfenzn" })
 			.reply(200, loader.json(`test/fixtures/client/wallets-page-1.json`));
 
 		const ark = await createMockService(ledger.wallets.record);
@@ -124,6 +128,12 @@ describe("LedgerService - scan", ({ assert, nock, beforeAll, it, loader, stub })
 
 	it("should scan for new wallets", async () => {
 		nock.fake(/.+/)
+			.post("/api/wallets/search", { limit: 1 })
+			.reply(404, {
+				error: "RequestException",
+				message: "HTTP request returned status code 404",
+				statusCode: 404,
+			})
 			.get("/api/wallets")
 			.query(true)
 			.reply(200, loader.json(`test/fixtures/client/wallets-page-0.json`))

--- a/packages/ark/source/ledger.service.test.ts
+++ b/packages/ark/source/ledger.service.test.ts
@@ -103,10 +103,16 @@ describe("LedgerService - scan", ({ assert, nock, beforeAll, it, loader, stub })
 				statusCode: 404,
 			})
 			.get("/api/wallets")
-			.query({ address: "D9xJncW4ECUSJQWeLP7wncxhDTvNeg2HNK,DFgggtreMXQNQKnxHddvkaPHcQbRdK3jyJ,DFr1CR81idSmfgQ19KXe4M6keqUEAuU8kF,DTYiNbvTKveMtJC8KPPdBrgRWxfPxGp1WV,DJyGFrZv4MYKrTMcjzEyhZzdTAJju2Rcjr" })
+			.query({
+				address:
+					"D9xJncW4ECUSJQWeLP7wncxhDTvNeg2HNK,DFgggtreMXQNQKnxHddvkaPHcQbRdK3jyJ,DFr1CR81idSmfgQ19KXe4M6keqUEAuU8kF,DTYiNbvTKveMtJC8KPPdBrgRWxfPxGp1WV,DJyGFrZv4MYKrTMcjzEyhZzdTAJju2Rcjr",
+			})
 			.reply(200, loader.json(`test/fixtures/client/wallets-page-0.json`))
 			.get("/api/wallets")
-			.query({ address: "DHnV81YdhYDkwCLD8pkxiXh53pGFw435GS,DGhLzafzQpBYjDAWP41U4cx5CKZ5BdSnS3,DLVXZyKFxLLdyuEtJRUvFoKcorSrnBnq48,DFZAfJ1i1LsvhkUk76Piw4v7oTgq12pX9Z,DGfNF9bGPss6YKLEqK5gwr4C1M7vgfenzn" })
+			.query({
+				address:
+					"DHnV81YdhYDkwCLD8pkxiXh53pGFw435GS,DGhLzafzQpBYjDAWP41U4cx5CKZ5BdSnS3,DLVXZyKFxLLdyuEtJRUvFoKcorSrnBnq48,DFZAfJ1i1LsvhkUk76Piw4v7oTgq12pX9Z,DGfNF9bGPss6YKLEqK5gwr4C1M7vgfenzn",
+			})
 			.reply(200, loader.json(`test/fixtures/client/wallets-page-1.json`));
 
 		const ark = await createMockService(ledger.wallets.record);

--- a/packages/profiles/source/notification.service.test.ts
+++ b/packages/profiles/source/notification.service.test.ts
@@ -28,6 +28,12 @@ describeWithContext(
 				.reply(200, loader.json("test/fixtures/client/syncing.json"))
 				.get("/api/peers")
 				.reply(200, loader.json("test/fixtures/client/peers.json"))
+				.post("/api/wallets/search", { limit: 1 })
+				.reply(404, {
+					error: "RequestException",
+					message: "HTTP request returned status code 404",
+					statusCode: 404,
+				})
 				.get("/api/wallets/D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW")
 				.reply(200, loader.json("test/fixtures/client/wallet.json"))
 				.get("/api/transactions")

--- a/packages/profiles/source/notification.transactions.service.test.ts
+++ b/packages/profiles/source/notification.transactions.service.test.ts
@@ -25,6 +25,12 @@ describeWithContext(
 				.reply(200, loader.json("test/fixtures/client/peers.json"))
 				.get("/api/node/syncing")
 				.reply(200, loader.json("test/fixtures/client/syncing.json"))
+				.post("/api/wallets/search", { limit: 1 })
+				.reply(404, {
+					error: "RequestException",
+					message: "HTTP request returned status code 404",
+					statusCode: 404,
+				})
 				.get("/api/wallets/D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW")
 				.reply(200, loader.json("test/fixtures/client/wallet.json"))
 				.persist();

--- a/packages/profiles/source/transaction-index.test.ts
+++ b/packages/profiles/source/transaction-index.test.ts
@@ -20,6 +20,13 @@ describe("TransactionIndex", ({ beforeAll, beforeEach, nock, assert, it, loader 
 			.get("/api/node/syncing")
 			.reply(200, loader.json("test/fixtures/client/syncing.json"))
 
+			.post("/api/wallets/search", { limit: 1 })
+			.reply(404, {
+				error: "RequestException",
+				message: "HTTP request returned status code 404",
+				statusCode: 404,
+			})
+
 			// default wallet
 			.get("/api/wallets/D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW")
 			.reply(200, loader.json("test/fixtures/client/wallet-non-resigned.json"))

--- a/packages/profiles/source/transaction.aggregate.test.ts
+++ b/packages/profiles/source/transaction.aggregate.test.ts
@@ -25,6 +25,12 @@ describe("TransactionAggregate", ({ each, loader, afterEach, beforeAll, beforeEa
 			.reply(200, loader.json("test/fixtures/client/peers.json"))
 			.get("/api/node/syncing")
 			.reply(200, loader.json("test/fixtures/client/syncing.json"))
+			.post("/api/wallets/search", { limit: 1 })
+			.reply(404, {
+				error: "RequestException",
+				message: "HTTP request returned status code 404",
+				statusCode: 404,
+			})
 			.get("/api/wallets/D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW")
 			.reply(200, loader.json("test/fixtures/client/wallet.json"))
 			.persist();

--- a/packages/profiles/source/wallet.test.ts
+++ b/packages/profiles/source/wallet.test.ts
@@ -29,6 +29,13 @@ describe("Wallet", ({ beforeAll, beforeEach, loader, nock, assert, stub, it }) =
 			.get("/api/node/syncing")
 			.reply(200, loader.json("test/fixtures/client/syncing.json"))
 
+			.post("/api/wallets/search", { limit: 1 })
+			.reply(404, {
+				error: "RequestException",
+				message: "HTTP request returned status code 404",
+				statusCode: 404,
+			})
+
 			// default wallet
 			.get("/api/wallets/D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW")
 			.reply(200, loader.json("test/fixtures/client/wallet-non-resigned.json"))


### PR DESCRIPTION
https://app.clickup.com/t/2mez868

Refactors the legacy API check on a  response to the `/api/wallets/search [POST]` endpoint instead of the networks' name, as this endpoint is only present on legacy networks.