### PR TITLE
fix(ark): adjust query used to determine if legacy and store status for each network

### DIFF
--- a/packages/ark/source/client.service.test.ts
+++ b/packages/ark/source/client.service.test.ts
@@ -34,9 +34,13 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 
 	it("should retrieve a list of transactions for a single address via Core 2.0", async (context) => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", {})
-			.query({ limit: 1 })
-			.reply(200, {})
+			.get("/api/wallets")
+			.query({ limit: 1, nonce: 0 })
+			.reply(422, {
+				error: "RequestException",
+				message: "HTTP request returned status code 422",
+				statusCode: 422,
+			})
 			.post("/api/transactions/search", { addresses: ["DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8"] })
 			.query({ page: "0" })
 			.reply(200, loader.json(`test/fixtures/client/transactions.json`));
@@ -52,9 +56,13 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 
 	it("should retrieve a list of transactions for multiple addresses via Core 2.0", async (context) => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", {})
-			.query({ limit: 1 })
-			.reply(200, {})
+			.get("/api/wallets")
+			.query({ limit: 1, nonce: 0 })
+			.reply(422, {
+				error: "RequestException",
+				message: "HTTP request returned status code 422",
+				statusCode: 422,
+			})
 			.post("/api/transactions/search", {
 				addresses: ["DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8", "DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5"],
 			})
@@ -75,13 +83,9 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 
 	it("should retrieve a list of transactions for a single address via Core 3.0", async (context) => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", {})
-			.query({ limit: 1 })
-			.reply(404, {
-				error: "RequestException",
-				message: "HTTP request returned status code 404",
-				statusCode: 404,
-			})
+			.get("/api/wallets")
+			.query({ limit: 1, nonce: 0 })
+			.reply(200, {})
 			.get("/api/transactions")
 			.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8" })
 			.reply(200, loader.json(`test/fixtures/client/transactions.json`));
@@ -96,13 +100,9 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 
 	it("should retrieve a list of transactions for multiple addresses via Core 3.0", async (context) => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", {})
-			.query({ limit: 1 })
-			.reply(404, {
-				error: "RequestException",
-				message: "HTTP request returned status code 404",
-				statusCode: 404,
-			})
+			.get("/api/wallets")
+			.query({ limit: 1, nonce: 0 })
+			.reply(200, {})
 			.get("/api/transactions")
 			.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8,DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5" })
 			.reply(200, loader.json(`test/fixtures/client/transactions.json`));
@@ -120,13 +120,9 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 
 	it("should retrieve a list of transactions for an advanced search via Core 3.0", async (context) => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", {})
-			.query({ limit: 1 })
-			.reply(404, {
-				error: "RequestException",
-				message: "HTTP request returned status code 404",
-				statusCode: 404,
-			})
+			.get("/api/wallets")
+			.query({ limit: 1, nonce: 0 })
+			.reply(200, {})
 			.get("/api/transactions")
 			.query({
 				address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8",
@@ -149,13 +145,9 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 
 	it("should retrieve a list of transactions for an advanced search including timestamp via Core 3.0", async (context) => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", {})
-			.query({ limit: 1 })
-			.reply(404, {
-				error: "RequestException",
-				message: "HTTP request returned status code 404",
-				statusCode: 404,
-			})
+			.get("/api/wallets")
+			.query({ limit: 1, nonce: 0 })
+			.reply(200, {})
 			.get("/api/transactions")
 			.query({
 				address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8",
@@ -201,9 +193,13 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 		});
 
 		nock.fake(/.+/)
-			.post("/api/wallets/search", {})
-			.query({ limit: 1 })
-			.reply(200, {})
+			.get("/api/wallets")
+			.query({ limit: 1, nonce: 0 })
+			.reply(422, {
+				error: "RequestException",
+				message: "HTTP request returned status code 422",
+				statusCode: 422,
+			})
 			.post("/api/wallets/search", { addresses: ["DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8"] })
 			.reply(200, loader.json(`test/fixtures/client/wallets.json`));
 
@@ -227,13 +223,9 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 		});
 
 		nock.fake(/.+/)
-			.post("/api/wallets/search", {})
-			.query({ limit: 1 })
-			.reply(404, {
-				error: "RequestException",
-				message: "HTTP request returned status code 404",
-				statusCode: 404,
-			})
+			.get("/api/wallets")
+			.query({ limit: 1, nonce: 0 })
+			.reply(200, {})
 			.get("/api/wallets")
 			.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8" })
 			.reply(200, loader.json(`test/fixtures/client/wallets.json`));

--- a/packages/ark/source/client.service.test.ts
+++ b/packages/ark/source/client.service.test.ts
@@ -34,7 +34,8 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 
 	it("should retrieve a list of transactions for a single address via Core 2.0", async (context) => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", { limit: 1 })
+			.post("/api/wallets/search", {})
+			.query({ limit: 1 })
 			.reply(200, {})
 			.post("/api/transactions/search", { addresses: ["DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8"] })
 			.query({ page: "0" })
@@ -51,7 +52,8 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 
 	it("should retrieve a list of transactions for multiple addresses via Core 2.0", async (context) => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", { limit: 1 })
+			.post("/api/wallets/search", {})
+			.query({ limit: 1 })
 			.reply(200, {})
 			.post("/api/transactions/search", {
 				addresses: ["DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8", "DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5"],
@@ -73,7 +75,8 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 
 	it("should retrieve a list of transactions for a single address via Core 3.0", async (context) => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", { limit: 1 })
+			.post("/api/wallets/search", {})
+			.query({ limit: 1 })
 			.reply(404, {
 				error: "RequestException",
 				message: "HTTP request returned status code 404",
@@ -93,7 +96,8 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 
 	it("should retrieve a list of transactions for multiple addresses via Core 3.0", async (context) => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", { limit: 1 })
+			.post("/api/wallets/search", {})
+			.query({ limit: 1 })
 			.reply(404, {
 				error: "RequestException",
 				message: "HTTP request returned status code 404",
@@ -116,7 +120,8 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 
 	it("should retrieve a list of transactions for an advanced search via Core 3.0", async (context) => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", { limit: 1 })
+			.post("/api/wallets/search", {})
+			.query({ limit: 1 })
 			.reply(404, {
 				error: "RequestException",
 				message: "HTTP request returned status code 404",
@@ -144,7 +149,8 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 
 	it("should retrieve a list of transactions for an advanced search including timestamp via Core 3.0", async (context) => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", { limit: 1 })
+			.post("/api/wallets/search", {})
+			.query({ limit: 1 })
 			.reply(404, {
 				error: "RequestException",
 				message: "HTTP request returned status code 404",
@@ -195,7 +201,8 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 		});
 
 		nock.fake(/.+/)
-			.post("/api/wallets/search", { limit: 1 })
+			.post("/api/wallets/search", {})
+			.query({ limit: 1 })
 			.reply(200, {})
 			.post("/api/wallets/search", { addresses: ["DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8"] })
 			.reply(200, loader.json(`test/fixtures/client/wallets.json`));
@@ -220,7 +227,8 @@ describe("ClientService", async ({ assert, nock, beforeEach, it, loader }) => {
 		});
 
 		nock.fake(/.+/)
-			.post("/api/wallets/search", { limit: 1 })
+			.post("/api/wallets/search", {})
+			.query({ limit: 1 })
 			.reply(404, {
 				error: "RequestException",
 				message: "HTTP request returned status code 404",

--- a/packages/ark/source/client.service.ts
+++ b/packages/ark/source/client.service.ts
@@ -344,16 +344,18 @@ export class ClientService extends Services.AbstractClientService {
 		}
 
 		try {
-			await this.#request.post("wallets/search", {
-				body: {},
+			await this.#request.get("wallets", {
 				searchParams: {
 					limit: 1,
+					nonce: 0,
 				},
 			});
 
-			this.#isLegacyMap.set(network, true);
+			this.#isLegacyMap.set(network, false);
 		} catch (error) {
-			this.#isLegacyMap.set(network, !error.message.includes("404"));
+			if (error.message.includes(422)) {
+				this.#isLegacyMap.set(network, true);
+			}
 		}
 	}
 }

--- a/packages/ark/source/client.service.ts
+++ b/packages/ark/source/client.service.ts
@@ -332,7 +332,8 @@ export class ClientService extends Services.AbstractClientService {
 		if (this.#isLegacy === undefined) {
 			try {
 				await this.#request.post("wallets/search", {
-					body: {
+					body: {},
+					searchParams: {
 						limit: 1,
 					},
 				});

--- a/packages/ark/source/client.service.ts
+++ b/packages/ark/source/client.service.ts
@@ -32,9 +32,11 @@ export class ClientService extends Services.AbstractClientService {
 	public override async transactions(
 		query: Services.ClientTransactionsInput,
 	): Promise<Collections.ConfirmedTransactionDataCollection> {
-		await this.#setLegacy();
+		const network = this.configRepository.get<string>("network.id");
 
-		const response = this.#isLegacy(this.configRepository.get<string>("network.id"))
+		await this.#setLegacy(network);
+
+		const response = this.#isLegacy(network)
 			? await this.#request.post("transactions/search", this.#createSearchParams(query))
 			: await this.#request.get("transactions", this.#createSearchParams(query));
 
@@ -48,9 +50,11 @@ export class ClientService extends Services.AbstractClientService {
 	}
 
 	public override async wallets(query: Services.ClientWalletsInput): Promise<Collections.WalletDataCollection> {
-		await this.#setLegacy();
+		const network = this.configRepository.get<string>("network.id");
 
-		const response = this.#isLegacy(this.configRepository.get<string>("network.id"))
+		await this.#setLegacy(network);
+
+		const response = this.#isLegacy(network)
 			? await this.#request.post("wallets/search", this.#createSearchParams(query))
 			: await this.#request.get("wallets", this.#createSearchParams(query));
 
@@ -67,7 +71,7 @@ export class ClientService extends Services.AbstractClientService {
 	}
 
 	public override async delegates(query?: Contracts.KeyValuePair): Promise<Collections.WalletDataCollection> {
-		await this.#setLegacy();
+		await this.#setLegacy(this.configRepository.get<string>("network.id"));
 
 		const body = await this.#request.get("delegates", this.#createSearchParams(query || {}));
 
@@ -334,9 +338,7 @@ export class ClientService extends Services.AbstractClientService {
 		return this.#isLegacyMap.get(network);
 	}
 
-	async #setLegacy(): Promise<void> {
-		const network = this.configRepository.get<string>("network.id");
-
+	async #setLegacy(network: string): Promise<void> {
 		if (this.#isLegacyMap.get(network) !== undefined) {
 			return;
 		}

--- a/packages/ark/source/ledger.service.test.ts
+++ b/packages/ark/source/ledger.service.test.ts
@@ -96,13 +96,9 @@ describe("LedgerService - scan", ({ assert, nock, beforeAll, it, loader, stub })
 
 	it("should scan for legacy wallets", async () => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", {})
-			.query({ limit: 1 })
-			.reply(404, {
-				error: "RequestException",
-				message: "HTTP request returned status code 404",
-				statusCode: 404,
-			})
+			.post("/api/wallets")
+			.query({ limit: 1, nonce: 0 })
+			.reply(200, {})
 			.get("/api/wallets")
 			.query({
 				address:
@@ -135,13 +131,9 @@ describe("LedgerService - scan", ({ assert, nock, beforeAll, it, loader, stub })
 
 	it("should scan for new wallets", async () => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", {})
-			.query({ limit: 1 })
-			.reply(404, {
-				error: "RequestException",
-				message: "HTTP request returned status code 404",
-				statusCode: 404,
-			})
+			.post("/api/wallets")
+			.query({ limit: 1, nonce: 0 })
+			.reply(200, {})
 			.get("/api/wallets")
 			.query(true)
 			.reply(200, loader.json(`test/fixtures/client/wallets-page-0.json`))

--- a/packages/ark/source/ledger.service.test.ts
+++ b/packages/ark/source/ledger.service.test.ts
@@ -96,7 +96,8 @@ describe("LedgerService - scan", ({ assert, nock, beforeAll, it, loader, stub })
 
 	it("should scan for legacy wallets", async () => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", { limit: 1 })
+			.post("/api/wallets/search", {})
+			.query({ limit: 1 })
 			.reply(404, {
 				error: "RequestException",
 				message: "HTTP request returned status code 404",
@@ -134,7 +135,8 @@ describe("LedgerService - scan", ({ assert, nock, beforeAll, it, loader, stub })
 
 	it("should scan for new wallets", async () => {
 		nock.fake(/.+/)
-			.post("/api/wallets/search", { limit: 1 })
+			.post("/api/wallets/search", {})
+			.query({ limit: 1 })
 			.reply(404, {
 				error: "RequestException",
 				message: "HTTP request returned status code 404",

--- a/packages/profiles/source/notification.service.test.ts
+++ b/packages/profiles/source/notification.service.test.ts
@@ -28,7 +28,8 @@ describeWithContext(
 				.reply(200, loader.json("test/fixtures/client/syncing.json"))
 				.get("/api/peers")
 				.reply(200, loader.json("test/fixtures/client/peers.json"))
-				.post("/api/wallets/search", { limit: 1 })
+				.post("/api/wallets/search", {})
+				.query({ limit: 1 })
 				.reply(404, {
 					error: "RequestException",
 					message: "HTTP request returned status code 404",

--- a/packages/profiles/source/notification.transactions.service.test.ts
+++ b/packages/profiles/source/notification.transactions.service.test.ts
@@ -25,7 +25,8 @@ describeWithContext(
 				.reply(200, loader.json("test/fixtures/client/peers.json"))
 				.get("/api/node/syncing")
 				.reply(200, loader.json("test/fixtures/client/syncing.json"))
-				.post("/api/wallets/search", { limit: 1 })
+				.post("/api/wallets/search", {})
+				.query({ limit: 1 })
 				.reply(404, {
 					error: "RequestException",
 					message: "HTTP request returned status code 404",

--- a/packages/profiles/source/transaction-index.test.ts
+++ b/packages/profiles/source/transaction-index.test.ts
@@ -20,7 +20,8 @@ describe("TransactionIndex", ({ beforeAll, beforeEach, nock, assert, it, loader 
 			.get("/api/node/syncing")
 			.reply(200, loader.json("test/fixtures/client/syncing.json"))
 
-			.post("/api/wallets/search", { limit: 1 })
+			.post("/api/wallets/search", {})
+			.query({ limit: 1 })
 			.reply(404, {
 				error: "RequestException",
 				message: "HTTP request returned status code 404",

--- a/packages/profiles/source/transaction.aggregate.test.ts
+++ b/packages/profiles/source/transaction.aggregate.test.ts
@@ -25,7 +25,8 @@ describe("TransactionAggregate", ({ each, loader, afterEach, beforeAll, beforeEa
 			.reply(200, loader.json("test/fixtures/client/peers.json"))
 			.get("/api/node/syncing")
 			.reply(200, loader.json("test/fixtures/client/syncing.json"))
-			.post("/api/wallets/search", { limit: 1 })
+			.post("/api/wallets/search", {})
+			.query({ limit: 1 })
 			.reply(404, {
 				error: "RequestException",
 				message: "HTTP request returned status code 404",

--- a/packages/profiles/source/wallet.test.ts
+++ b/packages/profiles/source/wallet.test.ts
@@ -29,7 +29,8 @@ describe("Wallet", ({ beforeAll, beforeEach, loader, nock, assert, stub, it }) =
 			.get("/api/node/syncing")
 			.reply(200, loader.json("test/fixtures/client/syncing.json"))
 
-			.post("/api/wallets/search", { limit: 1 })
+			.post("/api/wallets/search", {})
+			.query({ limit: 1 })
 			.reply(404, {
 				error: "RequestException",
 				message: "HTTP request returned status code 404",


### PR DESCRIPTION
Follow up to https://github.com/ArdentHQ/platform-sdk/pull/11: use `api/wallets?limit=1&nonce=0 [GET]` as query instead of the previous POST request against the search endpoint.