### PR TITLE
refactor(profiles): only sync wallets of available networks

### DIFF
--- a/packages/profiles/source/notification.service.test.ts
+++ b/packages/profiles/source/notification.service.test.ts
@@ -28,13 +28,9 @@ describeWithContext(
 				.reply(200, loader.json("test/fixtures/client/syncing.json"))
 				.get("/api/peers")
 				.reply(200, loader.json("test/fixtures/client/peers.json"))
-				.post("/api/wallets/search", {})
-				.query({ limit: 1 })
-				.reply(404, {
-					error: "RequestException",
-					message: "HTTP request returned status code 404",
-					statusCode: 404,
-				})
+				.get("/api/wallets", {})
+				.query({ limit: 1, nonce: 0 })
+				.reply(200, {})
 				.get("/api/wallets/D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW")
 				.reply(200, loader.json("test/fixtures/client/wallet.json"))
 				.get("/api/transactions")

--- a/packages/profiles/source/notification.transactions.service.test.ts
+++ b/packages/profiles/source/notification.transactions.service.test.ts
@@ -25,13 +25,9 @@ describeWithContext(
 				.reply(200, loader.json("test/fixtures/client/peers.json"))
 				.get("/api/node/syncing")
 				.reply(200, loader.json("test/fixtures/client/syncing.json"))
-				.post("/api/wallets/search", {})
-				.query({ limit: 1 })
-				.reply(404, {
-					error: "RequestException",
-					message: "HTTP request returned status code 404",
-					statusCode: 404,
-				})
+				.get("/api/wallets", {})
+				.query({ limit: 1, nonce: 0 })
+				.reply(200, {})
 				.get("/api/wallets/D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW")
 				.reply(200, loader.json("test/fixtures/client/wallet.json"))
 				.persist();

--- a/packages/profiles/source/transaction-index.test.ts
+++ b/packages/profiles/source/transaction-index.test.ts
@@ -20,13 +20,9 @@ describe("TransactionIndex", ({ beforeAll, beforeEach, nock, assert, it, loader 
 			.get("/api/node/syncing")
 			.reply(200, loader.json("test/fixtures/client/syncing.json"))
 
-			.post("/api/wallets/search", {})
-			.query({ limit: 1 })
-			.reply(404, {
-				error: "RequestException",
-				message: "HTTP request returned status code 404",
-				statusCode: 404,
-			})
+			.get("/api/wallets", {})
+			.query({ limit: 1, nonce: 0 })
+			.reply(200, {})
 
 			// default wallet
 			.get("/api/wallets/D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW")

--- a/packages/profiles/source/transaction.aggregate.test.ts
+++ b/packages/profiles/source/transaction.aggregate.test.ts
@@ -25,13 +25,9 @@ describe("TransactionAggregate", ({ each, loader, afterEach, beforeAll, beforeEa
 			.reply(200, loader.json("test/fixtures/client/peers.json"))
 			.get("/api/node/syncing")
 			.reply(200, loader.json("test/fixtures/client/syncing.json"))
-			.post("/api/wallets/search", {})
-			.query({ limit: 1 })
-			.reply(404, {
-				error: "RequestException",
-				message: "HTTP request returned status code 404",
-				statusCode: 404,
-			})
+			.get("/api/wallets", {})
+			.query({ limit: 1, nonce: 0 })
+			.reply(200, {})
 			.get("/api/wallets/D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW")
 			.reply(200, loader.json("test/fixtures/client/wallet.json"))
 			.persist();

--- a/packages/profiles/source/wallet.service.test.ts
+++ b/packages/profiles/source/wallet.service.test.ts
@@ -7,7 +7,7 @@ import { Identifiers } from "./container.models";
 import { ProfileRepository } from "./profile.repository";
 import { WalletService } from "./wallet.service.js";
 
-describe("WalletService", ({ afterEach, beforeAll, beforeEach, loader, nock, assert, stub, it }) => {
+describe("WalletService", ({ beforeAll, beforeEach, loader, nock, assert, stub, it }) => {
 	beforeAll(() => bootContainer());
 
 	beforeEach(async (context) => {
@@ -72,7 +72,11 @@ describe("WalletService", ({ afterEach, beforeAll, beforeEach, loader, nock, ass
 
 		context.profile = await profileRepository.create("John Doe");
 
+		context.profile.coins().set("ARK", "ark.devnet");
+
 		context.wallet = await importByMnemonic(context.profile, identity.mnemonic, "ARK", "ark.devnet");
+
+		context.networkSpy = stub(context.profile, "availableNetworks").returnValue([context.wallet.network()]);
 
 		context.liveSpy = stub(context.wallet.network(), "isLive").returnValue(true);
 		context.testSpy = stub(context.wallet.network(), "isTest").returnValue(false);
@@ -87,7 +91,7 @@ describe("WalletService", ({ afterEach, beforeAll, beforeEach, loader, nock, ass
 
 		assert.not.throws(() => context.wallet.voting().current(), /has not been synced/);
 
-		stub(context.profile.wallets(), "values").returnValue([undefined]);
+		stub(context.profile.wallets(), "values").returnValue([]);
 		await context.subject.syncByProfile(context.profile);
 	});
 });

--- a/packages/profiles/source/wallet.service.ts
+++ b/packages/profiles/source/wallet.service.ts
@@ -4,9 +4,14 @@ import { pqueueSettled } from "./helpers/queue.js";
 export class WalletService implements IWalletService {
 	/** {@inheritDoc IWalletService.syncByProfile} */
 	public async syncByProfile(profile: IProfile): Promise<void> {
+		const availableNetworkIds = profile.availableNetworks().map((network) => network.id());
+
+		const wallets = profile.wallets().values()
+			.filter((wallet) => availableNetworkIds.includes(wallet.networkId()));
+
 		const promises: (() => Promise<void>)[] = [];
 
-		for (const wallet of profile.wallets().values()) {
+		for (const wallet of wallets) {
 			promises.push(
 				() => wallet?.synchroniser().identity(),
 				() => wallet?.synchroniser().votes(),

--- a/packages/profiles/source/wallet.service.ts
+++ b/packages/profiles/source/wallet.service.ts
@@ -6,7 +6,9 @@ export class WalletService implements IWalletService {
 	public async syncByProfile(profile: IProfile): Promise<void> {
 		const availableNetworkIds = profile.availableNetworks().map((network) => network.id());
 
-		const wallets = profile.wallets().values()
+		const wallets = profile
+			.wallets()
+			.values()
 			.filter((wallet) => availableNetworkIds.includes(wallet.networkId()));
 
 		const promises: (() => Promise<void>)[] = [];

--- a/packages/profiles/source/wallet.test.ts
+++ b/packages/profiles/source/wallet.test.ts
@@ -29,13 +29,9 @@ describe("Wallet", ({ beforeAll, beforeEach, loader, nock, assert, stub, it }) =
 			.get("/api/node/syncing")
 			.reply(200, loader.json("test/fixtures/client/syncing.json"))
 
-			.post("/api/wallets/search", {})
-			.query({ limit: 1 })
-			.reply(404, {
-				error: "RequestException",
-				message: "HTTP request returned status code 404",
-				statusCode: 404,
-			})
+			.get("/api/wallets", {})
+			.query({ limit: 1, nonce: 0 })
+			.reply(200, {})
 
 			// default wallet
 			.get("/api/wallets/D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW")


### PR DESCRIPTION
https://app.clickup.com/t/30cpn1g

Instead of syncing all wallets, we can sync only those pertaining to available networks.

Goes hand in hand with https://github.com/ArdentHQ/arkvault/pull/195.