### PR TITLE
refactor(profiles): check if networks are enabled

### DIFF
--- a/packages/profiles/source/wallet.service.ts
+++ b/packages/profiles/source/wallet.service.ts
@@ -4,12 +4,17 @@ import { pqueueSettled } from "./helpers/queue.js";
 export class WalletService implements IWalletService {
 	/** {@inheritDoc IWalletService.syncByProfile} */
 	public async syncByProfile(profile: IProfile): Promise<void> {
-		const availableNetworkIds = profile.availableNetworks().map((network) => network.id());
+		const availableNetworkIds = new Set(
+			profile
+				.availableNetworks()
+				.filter((network) => network.meta().enabled === undefined || network.meta().enabled === true)
+				.map((network) => network.id()),
+		);
 
 		const wallets = profile
 			.wallets()
 			.values()
-			.filter((wallet) => availableNetworkIds.includes(wallet.networkId()));
+			.filter((wallet) => availableNetworkIds.has(wallet.networkId()));
 
 		const promises: (() => Promise<void>)[] = [];
 


### PR DESCRIPTION
Default and custom networks are stored slightly different on the profile, i.e. disabled default networks are excluded from `profile.availableNetworks()` while disabled custom networks are included, but have their `network.meta().enabled` flag set to false. This flag is not used by default networks.