### PR TITLE
feat(profiles): include additional fields in profile settings

### DIFF
--- a/packages/profiles/source/environment.test.ts
+++ b/packages/profiles/source/environment.test.ts
@@ -433,6 +433,7 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 		await makeSubject(context);
 
 		const john = await context.subject.profiles().create("John");
+
 		await importByMnemonic(john, identity.mnemonic, "ARK", "ark.devnet");
 		await context.subject.profiles().persist(john);
 
@@ -443,6 +444,10 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 		const jack = await context.subject.profiles().create("Jack");
 		jack.auth().setPassword("password");
 		await context.subject.profiles().persist(jack);
+
+		john.settings().set(ProfileSetting.HasOnboarded, false);
+		jack.settings().set(ProfileSetting.HasOnboarded, false);
+		jane.settings().set(ProfileSetting.HasOnboarded, false);
 
 		await context.subject.persist();
 

--- a/packages/profiles/source/environment.test.ts
+++ b/packages/profiles/source/environment.test.ts
@@ -166,7 +166,6 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 		profile.settings().set("ADVANCED_MODE", false);
 
 		// Create a Setting
-		profile.settings().set(ProfileSetting.HasOnboarded, true);
 		profile.settings().set(ProfileSetting.LastVisitedPage, { name: "test", data: { foo: "bar" } });
 
 		// Encode all data
@@ -224,7 +223,6 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 			USE_EXPANDED_TABLES: false,
 			USE_NETWORK_WALLET_NAMES: false,
 			USE_TEST_NETWORKS: false,
-			HAS_ONBOARDED: true,
 			LAST_VISITED_PAGE: { name: "test", data: { foo: "bar" } },
 		});
 	});
@@ -240,6 +238,7 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 		await environment.boot();
 
 		const newProfile = environment.profiles().findById("8101538b-b13a-4b8d-b3d8-e710ccffd385");
+		newProfile.settings().set(ProfileSetting.HasOnboarded, true);
 
 		await new ProfileImporter(newProfile).import();
 
@@ -250,6 +249,7 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 		assert.equal(newProfile.data().all(), {
 			LATEST_MIGRATION: "0.0.0",
 		});
+
 		assert.equal(newProfile.settings().all(), {
 			ACCENT_COLOR: "green",
 			ADVANCED_MODE: false,
@@ -268,7 +268,7 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 			USE_EXPANDED_TABLES: false,
 			USE_NETWORK_WALLET_NAMES: false,
 			USE_TEST_NETWORKS: false,
-			HAS_ONBOARDED: false,
+			HAS_ONBOARDED: true,
 		});
 
 		const restoredWallet = newProfile.wallets().first();

--- a/packages/profiles/source/environment.test.ts
+++ b/packages/profiles/source/environment.test.ts
@@ -166,7 +166,8 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 		profile.settings().set("ADVANCED_MODE", false);
 
 		// Create a Setting
-		profile.settings().set(ProfileSetting.PrimaryWalletId, "1");
+		profile.settings().set(ProfileSetting.HasOnboarded, true);
+		profile.settings().set(ProfileSetting.LastVisitedPage, { name: "test", data: { foo: "bar" } });
 
 		// Encode all data
 		await context.subject.profiles().persist(profile);
@@ -223,7 +224,8 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 			USE_EXPANDED_TABLES: false,
 			USE_NETWORK_WALLET_NAMES: false,
 			USE_TEST_NETWORKS: false,
-			PRIMARY_WALLET_ID: "1",
+			HAS_ONBOARDED: true,
+			LAST_VISITED_PAGE: { name: "test", data: { foo: "bar" } },
 		});
 	});
 

--- a/packages/profiles/source/environment.test.ts
+++ b/packages/profiles/source/environment.test.ts
@@ -268,6 +268,7 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 			USE_EXPANDED_TABLES: false,
 			USE_NETWORK_WALLET_NAMES: false,
 			USE_TEST_NETWORKS: false,
+			HAS_ONBOARDED: false,
 		});
 
 		const restoredWallet = newProfile.wallets().first();

--- a/packages/profiles/source/environment.test.ts
+++ b/packages/profiles/source/environment.test.ts
@@ -13,7 +13,7 @@ import { importByMnemonic } from "../test/mocking";
 import { StubStorage } from "../test/stubs/storage";
 import { container } from "./container";
 import { Identifiers } from "./container.models";
-import { ProfileData } from "./contracts";
+import { ProfileData, ProfileSetting } from "./contracts";
 import { DataRepository } from "./data.repository";
 import { Environment } from "./environment";
 import { ExchangeRateService } from "./exchange-rate.service.js";
@@ -165,6 +165,9 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 		// Create a Setting
 		profile.settings().set("ADVANCED_MODE", false);
 
+		// Create a Setting
+		profile.settings().set(ProfileSetting.PrimaryWalletId, "1");
+
 		// Encode all data
 		await context.subject.profiles().persist(profile);
 
@@ -220,6 +223,7 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 			USE_EXPANDED_TABLES: false,
 			USE_NETWORK_WALLET_NAMES: false,
 			USE_TEST_NETWORKS: false,
+			PRIMARY_WALLET_ID: "1",
 		});
 	});
 

--- a/packages/profiles/source/profile.enum.contract.ts
+++ b/packages/profiles/source/profile.enum.contract.ts
@@ -28,6 +28,9 @@ export enum ProfileSetting {
 	UseNetworkWalletNames = "USE_NETWORK_WALLET_NAMES",
 	UseTestNetworks = "USE_TEST_NETWORKS",
 	PrimaryWalletId = "PRIMARY_WALLET_ID",
+	LastVisitedPage = "LAST_VISITED_PAGE",
+	HasOnboarded = "HAS_ONBOARDED",
+	Sessions = "SESSIONS",
 }
 
 /**
@@ -40,5 +43,4 @@ export enum ProfileData {
 	LatestMigration = "LATEST_MIGRATION",
 	HasCompletedIntroductoryTutorial = "HAS_COMPLETED_INTRODUCTORY_TUTORIAL",
 	HasAcceptedManualInstallationDisclaimer = "HAS_ACCEPTED_MANUAL_INSTALLATION_DISCLAIMER",
-	LastScreen = "LAST_SCREEN",
 }

--- a/packages/profiles/source/profile.enum.contract.ts
+++ b/packages/profiles/source/profile.enum.contract.ts
@@ -27,7 +27,6 @@ export enum ProfileSetting {
 	UseExpandedTables = "USE_EXPANDED_TABLES",
 	UseNetworkWalletNames = "USE_NETWORK_WALLET_NAMES",
 	UseTestNetworks = "USE_TEST_NETWORKS",
-	PrimaryWalletId = "PRIMARY_WALLET_ID",
 	LastVisitedPage = "LAST_VISITED_PAGE",
 	HasOnboarded = "HAS_ONBOARDED",
 	Sessions = "SESSIONS",

--- a/packages/profiles/source/profile.enum.contract.ts
+++ b/packages/profiles/source/profile.enum.contract.ts
@@ -27,6 +27,7 @@ export enum ProfileSetting {
 	UseExpandedTables = "USE_EXPANDED_TABLES",
 	UseNetworkWalletNames = "USE_NETWORK_WALLET_NAMES",
 	UseTestNetworks = "USE_TEST_NETWORKS",
+	PrimaryWalletId = "PRIMARY_WALLET_ID",
 }
 
 /**
@@ -39,4 +40,5 @@ export enum ProfileData {
 	LatestMigration = "LATEST_MIGRATION",
 	HasCompletedIntroductoryTutorial = "HAS_COMPLETED_INTRODUCTORY_TUTORIAL",
 	HasAcceptedManualInstallationDisclaimer = "HAS_ACCEPTED_MANUAL_INSTALLATION_DISCLAIMER",
+	LastScreen = "LAST_SCREEN",
 }

--- a/packages/profiles/source/profile.test.ts
+++ b/packages/profiles/source/profile.test.ts
@@ -66,10 +66,34 @@ describe("Profile", ({ beforeEach, it, assert, loader, stub, nock }) => {
 		assert.is(context.subject.avatar(), "custom-avatar");
 	});
 
-	it("should have a primary wallet id", (context) => {
-		context.subject.settings().set(ProfileSetting.PrimaryWalletId, "1");
+	it("should have a last visited page", (context) => {
+		context.subject.settings().set(ProfileSetting.LastVisitedPage, {
+			name: "test",
+			data: { foo: "bar" },
+		});
 
-		assert.is(context.subject.settings().get(ProfileSetting.PrimaryWalletId), "1");
+		assert.is(context.subject.settings().get(ProfileSetting.LastVisitedPage), {
+			name: "test",
+			data: { foo: "bar" },
+		});
+	});
+
+	it("should have onboarded setting", (context) => {
+		context.subject.settings().set(ProfileSetting.HasOnboarded, true);
+
+		assert.is(context.subject.settings().get(ProfileSetting.HasOnboarded), true);
+	});
+
+	it("should have sessions", (context) => {
+		const sessions = {
+			"1": {
+				name: "test",
+				data: { foo: "bar" },
+			},
+		};
+
+		context.subject.settings().set(ProfileSetting.Sessions, sessions);
+		assert.is(context.subject.settings().get(ProfileSetting.Sessions), sessions);
 	});
 
 	it("should have a custom avatar in data", (context) => {

--- a/packages/profiles/source/profile.test.ts
+++ b/packages/profiles/source/profile.test.ts
@@ -67,15 +67,14 @@ describe("Profile", ({ beforeEach, it, assert, loader, stub, nock }) => {
 	});
 
 	it("should have a last visited page", (context) => {
-		context.subject.settings().set(ProfileSetting.LastVisitedPage, {
+		const lastVisitedPage = {
 			name: "test",
 			data: { foo: "bar" },
-		});
+		};
 
-		assert.is(context.subject.settings().get(ProfileSetting.LastVisitedPage), {
-			name: "test",
-			data: { foo: "bar" },
-		});
+		context.subject.settings().set(ProfileSetting.LastVisitedPage, lastVisitedPage);
+
+		assert.is(context.subject.settings().get(ProfileSetting.LastVisitedPage), lastVisitedPage);
 	});
 
 	it("should have onboarded setting", (context) => {

--- a/packages/profiles/source/profile.test.ts
+++ b/packages/profiles/source/profile.test.ts
@@ -66,6 +66,12 @@ describe("Profile", ({ beforeEach, it, assert, loader, stub, nock }) => {
 		assert.is(context.subject.avatar(), "custom-avatar");
 	});
 
+	it("should have a primary wallet id", (context) => {
+		context.subject.settings().set(ProfileSetting.PrimaryWalletId, "1");
+
+		assert.is(context.subject.settings().get(ProfileSetting.PrimaryWalletId), "1");
+	});
+
 	it("should have a custom avatar in data", (context) => {
 		context.subject.getAttributes().set("data.avatar", "something");
 		context.subject.getAttributes().set("avatar", "custom-avatar");

--- a/packages/profiles/source/profile.validator.test.ts
+++ b/packages/profiles/source/profile.validator.test.ts
@@ -85,6 +85,9 @@ describe("ProfileValidator", ({ loader, it, assert, nock, beforeEach }) => {
 				[ProfileSetting.UseNetworkWalletNames]: false,
 				[ProfileSetting.UseTestNetworks]: false,
 				[ProfileSetting.PrimaryWalletId]: "3a7a9e03-c10b-4135-88e9-92e586d53e69",
+				[ProfileSetting.HasOnboarded]: true,
+				[ProfileSetting.LastVisitedPage]: { name: "test", data: { foo: "bar" } },
+				[ProfileSetting.Sessions]: { 1: { name: "test", data: { foo: "bar" } } },
 			},
 			wallets: {},
 		};

--- a/packages/profiles/source/profile.validator.test.ts
+++ b/packages/profiles/source/profile.validator.test.ts
@@ -84,6 +84,7 @@ describe("ProfileValidator", ({ loader, it, assert, nock, beforeEach }) => {
 				[ProfileSetting.UseExpandedTables]: false,
 				[ProfileSetting.UseNetworkWalletNames]: false,
 				[ProfileSetting.UseTestNetworks]: false,
+				[ProfileSetting.PrimaryWalletId]: "3a7a9e03-c10b-4135-88e9-92e586d53e69",
 			},
 			wallets: {},
 		};

--- a/packages/profiles/source/profile.validator.test.ts
+++ b/packages/profiles/source/profile.validator.test.ts
@@ -84,7 +84,6 @@ describe("ProfileValidator", ({ loader, it, assert, nock, beforeEach }) => {
 				[ProfileSetting.UseExpandedTables]: false,
 				[ProfileSetting.UseNetworkWalletNames]: false,
 				[ProfileSetting.UseTestNetworks]: false,
-				[ProfileSetting.PrimaryWalletId]: "3a7a9e03-c10b-4135-88e9-92e586d53e69",
 				[ProfileSetting.HasOnboarded]: true,
 				[ProfileSetting.LastVisitedPage]: { name: "test", data: { foo: "bar" } },
 				[ProfileSetting.Sessions]: { 1: { name: "test", data: { foo: "bar" } } },

--- a/packages/profiles/source/profile.validator.ts
+++ b/packages/profiles/source/profile.validator.ts
@@ -113,7 +113,6 @@ export class ProfileValidator implements IProfileValidator {
 				[ProfileSetting.UseExpandedTables]: Joi.boolean().default(false),
 				[ProfileSetting.UseNetworkWalletNames]: Joi.boolean().default(false),
 				[ProfileSetting.UseTestNetworks]: Joi.boolean().default(false),
-				[ProfileSetting.PrimaryWalletId]: Joi.string(),
 				[ProfileSetting.Sessions]: Joi.object(),
 				[ProfileSetting.LastVisitedPage]: Joi.object(),
 				[ProfileSetting.HasOnboarded]: Joi.boolean().default(false),

--- a/packages/profiles/source/profile.validator.ts
+++ b/packages/profiles/source/profile.validator.ts
@@ -115,7 +115,7 @@ export class ProfileValidator implements IProfileValidator {
 				[ProfileSetting.UseTestNetworks]: Joi.boolean().default(false),
 				[ProfileSetting.Sessions]: Joi.object(),
 				[ProfileSetting.LastVisitedPage]: Joi.object(),
-				[ProfileSetting.HasOnboarded]: Joi.boolean().default(false),
+				[ProfileSetting.HasOnboarded]: Joi.boolean(),
 			}).required(),
 			wallets: Joi.object().pattern(
 				Joi.string().uuid(),

--- a/packages/profiles/source/profile.validator.ts
+++ b/packages/profiles/source/profile.validator.ts
@@ -114,6 +114,9 @@ export class ProfileValidator implements IProfileValidator {
 				[ProfileSetting.UseNetworkWalletNames]: Joi.boolean().default(false),
 				[ProfileSetting.UseTestNetworks]: Joi.boolean().default(false),
 				[ProfileSetting.PrimaryWalletId]: Joi.string(),
+				[ProfileSetting.Sessions]: Joi.object(),
+				[ProfileSetting.LastVisitedPage]: Joi.object(),
+				[ProfileSetting.HasOnboarded]: Joi.boolean().default(false),
 			}).required(),
 			wallets: Joi.object().pattern(
 				Joi.string().uuid(),

--- a/packages/profiles/source/profile.validator.ts
+++ b/packages/profiles/source/profile.validator.ts
@@ -113,6 +113,7 @@ export class ProfileValidator implements IProfileValidator {
 				[ProfileSetting.UseExpandedTables]: Joi.boolean().default(false),
 				[ProfileSetting.UseNetworkWalletNames]: Joi.boolean().default(false),
 				[ProfileSetting.UseTestNetworks]: Joi.boolean().default(false),
+				[ProfileSetting.PrimaryWalletId]: Joi.string(),
 			}).required(),
 			wallets: Joi.object().pattern(
 				Joi.string().uuid(),


### PR DESCRIPTION
Closes https://app.clickup.com/t/86dru3pn5

Allows the following fields to be included & persisted in profile settings:
* `sessions` Object
* `hasOnboarded` Boolean
* `lastVisitedPage` Object