### PR TITLE
refactor: remove unused `hasOnboarded` profile setting

### DIFF
--- a/packages/profiles/source/environment.test.ts
+++ b/packages/profiles/source/environment.test.ts
@@ -238,7 +238,6 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 		await environment.boot();
 
 		const newProfile = environment.profiles().findById("8101538b-b13a-4b8d-b3d8-e710ccffd385");
-		newProfile.settings().set(ProfileSetting.HasOnboarded, true);
 
 		await new ProfileImporter(newProfile).import();
 
@@ -268,7 +267,6 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 			USE_EXPANDED_TABLES: false,
 			USE_NETWORK_WALLET_NAMES: false,
 			USE_TEST_NETWORKS: false,
-			HAS_ONBOARDED: true,
 		});
 
 		const restoredWallet = newProfile.wallets().first();
@@ -444,10 +442,6 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 		const jack = await context.subject.profiles().create("Jack");
 		jack.auth().setPassword("password");
 		await context.subject.profiles().persist(jack);
-
-		john.settings().set(ProfileSetting.HasOnboarded, false);
-		jack.settings().set(ProfileSetting.HasOnboarded, false);
-		jane.settings().set(ProfileSetting.HasOnboarded, false);
 
 		await context.subject.persist();
 

--- a/packages/profiles/source/profile.enum.contract.ts
+++ b/packages/profiles/source/profile.enum.contract.ts
@@ -28,7 +28,6 @@ export enum ProfileSetting {
 	UseNetworkWalletNames = "USE_NETWORK_WALLET_NAMES",
 	UseTestNetworks = "USE_TEST_NETWORKS",
 	LastVisitedPage = "LAST_VISITED_PAGE",
-	HasOnboarded = "HAS_ONBOARDED",
 	Sessions = "SESSIONS",
 }
 

--- a/packages/profiles/source/profile.test.ts
+++ b/packages/profiles/source/profile.test.ts
@@ -77,12 +77,6 @@ describe("Profile", ({ beforeEach, it, assert, loader, stub, nock }) => {
 		assert.is(context.subject.settings().get(ProfileSetting.LastVisitedPage), lastVisitedPage);
 	});
 
-	it("should have onboarded setting", (context) => {
-		context.subject.settings().set(ProfileSetting.HasOnboarded, true);
-
-		assert.is(context.subject.settings().get(ProfileSetting.HasOnboarded), true);
-	});
-
 	it("should have sessions", (context) => {
 		const sessions = {
 			"1": {

--- a/packages/profiles/source/profile.validator.test.ts
+++ b/packages/profiles/source/profile.validator.test.ts
@@ -84,7 +84,6 @@ describe("ProfileValidator", ({ loader, it, assert, nock, beforeEach }) => {
 				[ProfileSetting.UseExpandedTables]: false,
 				[ProfileSetting.UseNetworkWalletNames]: false,
 				[ProfileSetting.UseTestNetworks]: false,
-				[ProfileSetting.HasOnboarded]: true,
 				[ProfileSetting.LastVisitedPage]: { name: "test", data: { foo: "bar" } },
 				[ProfileSetting.Sessions]: { 1: { name: "test", data: { foo: "bar" } } },
 			},

--- a/packages/profiles/source/profile.validator.ts
+++ b/packages/profiles/source/profile.validator.ts
@@ -115,7 +115,6 @@ export class ProfileValidator implements IProfileValidator {
 				[ProfileSetting.UseTestNetworks]: Joi.boolean().default(false),
 				[ProfileSetting.Sessions]: Joi.object(),
 				[ProfileSetting.LastVisitedPage]: Joi.object(),
-				[ProfileSetting.HasOnboarded]: Joi.boolean(),
 			}).required(),
 			wallets: Joi.object().pattern(
 				Joi.string().uuid(),


### PR DESCRIPTION
With https://github.com/ArdentHQ/arkconnect-extension/pull/131 we don't need to store `hasOnboarded` in profile.settings()

Task https://app.clickup.com/t/86drujzwe