### PR TITLE
test: adjust `lastVisitedPage` input data

### DIFF
--- a/packages/profiles/source/environment.test.ts
+++ b/packages/profiles/source/environment.test.ts
@@ -166,7 +166,7 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 		profile.settings().set("ADVANCED_MODE", false);
 
 		// Create a Setting
-		profile.settings().set(ProfileSetting.LastVisitedPage, { name: "test", data: { foo: "bar" } });
+		profile.settings().set(ProfileSetting.LastVisitedPage, { path: "test", data: { foo: "bar" } });
 
 		// Encode all data
 		await context.subject.profiles().persist(profile);
@@ -223,7 +223,7 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 			USE_EXPANDED_TABLES: false,
 			USE_NETWORK_WALLET_NAMES: false,
 			USE_TEST_NETWORKS: false,
-			LAST_VISITED_PAGE: { name: "test", data: { foo: "bar" } },
+			LAST_VISITED_PAGE: { path: "test", data: { foo: "bar" } },
 		});
 	});
 

--- a/packages/profiles/source/profile.test.ts
+++ b/packages/profiles/source/profile.test.ts
@@ -68,7 +68,7 @@ describe("Profile", ({ beforeEach, it, assert, loader, stub, nock }) => {
 
 	it("should have a last visited page", (context) => {
 		const lastVisitedPage = {
-			name: "test",
+			path: "/test",
 			data: { foo: "bar" },
 		};
 

--- a/packages/profiles/source/profile.validator.test.ts
+++ b/packages/profiles/source/profile.validator.test.ts
@@ -85,7 +85,7 @@ describe("ProfileValidator", ({ loader, it, assert, nock, beforeEach }) => {
 				[ProfileSetting.UseNetworkWalletNames]: false,
 				[ProfileSetting.UseTestNetworks]: false,
 				[ProfileSetting.HasOnboarded]: true,
-				[ProfileSetting.LastVisitedPage]: { name: "test", data: { foo: "bar" } },
+				[ProfileSetting.LastVisitedPage]: { path: "test", data: { foo: "bar" } },
 				[ProfileSetting.Sessions]: { 1: { name: "test", data: { foo: "bar" } } },
 			},
 			wallets: {},


### PR DESCRIPTION
A minor adjustment in tests to use `path` instead of `name` for `lastVisitedPage` input data. 
See conversation https://github.com/ArdentHQ/arkconnect-extension/pull/143#pullrequestreview-1931087595