### PR TITLE
refactor: extend mainsail webpack config from base

### DIFF
--- a/packages/mainsail/source/transaction.service.ts
+++ b/packages/mainsail/source/transaction.service.ts
@@ -27,6 +27,7 @@ import { Container } from "@mainsail/container";
 import { milestones } from "./crypto/networks/devnet/milestones.js";
 import { network } from "./crypto/networks/devnet/network.js";
 
+
 export class TransactionService extends Services.AbstractTransactionService {
 	readonly #ledgerService!: Services.LedgerService;
 	readonly #addressService!: Services.AddressService;

--- a/packages/mainsail/source/transaction.service.ts
+++ b/packages/mainsail/source/transaction.service.ts
@@ -424,10 +424,10 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 		transaction.senderPublicKey(senderPublicKey);
 
-		const wallet = await this.clientService.wallet({ type: "address", value: address });
+		const transactionWallet = await this.clientService.wallet({ type: "address", value: address });
 
 		// Nonce may come from the input but currently does not apply, refer to the `#createFromData` method
-		transaction.nonce(wallet.nonce().plus(1).toFixed(0));
+		transaction.nonce(transactionWallet.nonce().plus(1).toFixed(0));
 
 		if (callback) {
 			callback({ data: input.data, transaction });

--- a/packages/mainsail/source/transaction.service.ts
+++ b/packages/mainsail/source/transaction.service.ts
@@ -27,7 +27,6 @@ import { Container } from "@mainsail/container";
 import { milestones } from "./crypto/networks/devnet/milestones.js";
 import { network } from "./crypto/networks/devnet/network.js";
 
-
 export class TransactionService extends Services.AbstractTransactionService {
 	readonly #ledgerService!: Services.LedgerService;
 	readonly #addressService!: Services.AddressService;

--- a/packages/mainsail/webpack.config.cjs
+++ b/packages/mainsail/webpack.config.cjs
@@ -1,63 +1,17 @@
-const path = require("path");
-const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
-const ResolveTypeScriptPlugin = require("resolve-typescript-plugin").default;
 const { IgnorePlugin, NormalModuleReplacementPlugin } = require("webpack");
+const baseConfig = require("../../webpack.config.cjs");
 
 module.exports = {
-	devtool: "source-map",
-	entry: path.resolve(process.cwd(), "source/index.ts"),
-	experiments: {
-		asyncWebAssembly: false,
-		outputModule: true,
-		topLevelAwait: true,
-	},
-	mode: "production",
+	...baseConfig,
 	module: {
-		rules: [
-			{
-				exclude: /node_modules/,
-				test: /\.tsx?$/,
-				use: {
-					loader: "babel-loader",
-					options: {
-						babelrc: false,
-						plugins: ["@babel/plugin-transform-runtime", "@babel/plugin-proposal-class-properties"],
-						presets: ["@babel/preset-env", "@babel/preset-typescript"],
-					},
-				},
-			},
-			{
-				test: /\.m?js$/,
-				resolve: {
-					fullySpecified: false,
-				},
-			},
-		],
-
+		...baseConfig.module,
 		// Silence
 		// WARNING in mainsail/packages/kernel/distribution/bootstrap/load-service-providers.js 63:49-65
 		// Critical dependency: the request of a dependency is an expression
 		exprContextCritical: false,
 	},
-	optimization: {
-		minimize: process.env.NODE_ENV === "production",
-		sideEffects: false,
-	},
-	output: {
-		clean: true,
-		filename: "index.js",
-		library: {
-			type: "module",
-		},
-		path: path.resolve(process.cwd(), "distribution/browser"),
-	},
-	performance: {
-		hints: "warning",
-		maxAssetSize: 10_485_760,
-		maxEntrypointSize: 10_485_760,
-	},
 	plugins: [
-		new NodePolyfillPlugin(),
+		...baseConfig.plugins,
 		new IgnorePlugin({
 			checkResource(resource, context) {
 				// 'glob' causes issues like
@@ -76,17 +30,6 @@ module.exports = {
 		}),
 	],
 	resolve: {
-		extensions: [".ts", ".js"],
-		fallback: {
-			child_process: false,
-			fs: false,
-			perf_hooks: false,
-			module: false,
-		},
-		plugins: [new ResolveTypeScriptPlugin()],
+		...baseConfig.resolve,
 	},
-	stats: {
-		errorDetails: true,
-	},
-	target: "web",
 };


### PR DESCRIPTION
Extends mainsail webpack.config from base, and removes duplicate config definitions.