### PR TITLE
fix: remove mocked timestamp and confirmation fields

### DIFF
--- a/packages/mainsail/source/confirmed-transaction.dto.ts
+++ b/packages/mainsail/source/confirmed-transaction.dto.ts
@@ -3,6 +3,7 @@ import { BigNumber } from "@ardenthq/sdk-helpers";
 import { DateTime } from "@ardenthq/sdk-intl";
 
 import { TransactionTypeService } from "./transaction-type.service.js";
+import { Identities } from "./crypto/index.js";
 
 export class ConfirmedTransactionData extends DTO.AbstractConfirmedTransactionData {
 	public override id(): string {
@@ -13,22 +14,16 @@ export class ConfirmedTransactionData extends DTO.AbstractConfirmedTransactionDa
 		return this.data.blockId;
 	}
 
-	// @TODO: Revert when timestamp will be available from /api/transactions endpoint.
 	public override timestamp(): DateTime | undefined {
-		// return DateTime.fromUnix(this.data.timestamp.unix);
-		return DateTime.make();
+		return DateTime.fromUnix(this.data.timestamp / 1000);
 	}
 
-	// @TODO: Revert when confirmations will be available from /api/transactions endpoint.
 	public override confirmations(): BigNumber {
-		// return BigNumber.make(this.data.confirmations);
-		return BigNumber.make(10);
+		return BigNumber.make(this.data.confirmations);
 	}
 
-	// @TODO: Revert when sender will be available from /api/transactions endpoint.
 	public override sender(): string {
-		// return this.data.sender;
-		return this.data.recipient;
+		return Identities.Address.fromPublicKey(this.data.senderPublicKey); // @TODO: handle network
 	}
 
 	public override recipient(): string {

--- a/packages/mainsail/source/confirmed-transaction.dto.ts
+++ b/packages/mainsail/source/confirmed-transaction.dto.ts
@@ -3,7 +3,6 @@ import { BigNumber } from "@ardenthq/sdk-helpers";
 import { DateTime } from "@ardenthq/sdk-intl";
 
 import { TransactionTypeService } from "./transaction-type.service.js";
-import { Identities } from "./crypto/index.js";
 
 export class ConfirmedTransactionData extends DTO.AbstractConfirmedTransactionData {
 	public override id(): string {
@@ -22,8 +21,10 @@ export class ConfirmedTransactionData extends DTO.AbstractConfirmedTransactionDa
 		return BigNumber.make(this.data.confirmations);
 	}
 
+	// @TODO: Revert when sender will be available from /api/transactions endpoint.
 	public override sender(): string {
-		return Identities.Address.fromPublicKey(this.data.senderPublicKey); // @TODO: handle network
+		// return this.data.sender;
+		return this.data.recipient;
 	}
 
 	public override recipient(): string {


### PR DESCRIPTION
https://app.clickup.com/t/86dt1r0pt

this only  handles the confirmation and timestamp mocks. For sender we need a network to derive the proper address from a public key if we have to go down that route