### PR TITLE
refactor(mainsail): expose `NetworkManager`

### DIFF
--- a/packages/mainsail/source/index.ts
+++ b/packages/mainsail/source/index.ts
@@ -19,6 +19,8 @@ import { WIFService } from "./wif.service.js";
 import { WalletData } from "./wallet.dto.js";
 import { manifest } from "./manifest.js";
 
+export * from "./crypto/managers/network.js";
+
 export const Mainsail: Coins.CoinBundle = bundle({
 	dataTransferObjects: {
 		ConfirmedTransactionData,


### PR DESCRIPTION
Exposes the NetworkManager instance in the sdk-mainsail package to allow consumers to access network configurations (milestones,  manifest).

Usage:

```tsx
import { NetworkManager } from '@ardenthq/sdk-mainsail`

const networkConfigs = new NetworkManager()
networkConfigs.all()
```






