### PR TITLE
fix: wallet cold/hot status issue

### DIFF
--- a/packages/profiles/source/transaction-index.ts
+++ b/packages/profiles/source/transaction-index.ts
@@ -61,13 +61,13 @@ export class TransactionIndex implements ITransactionIndex {
 
 		const transactions = result.items();
 
-		if (this.#wallet.isCold() && transactions.some((t) => t.isSent() || t.isReturn())) {
-			this.#wallet.data().set(WalletData.Status, WalletFlag.Hot);
-		}
-
 		for (const transaction of transactions) {
 			transaction.setMeta("address", this.#wallet.address());
 			transaction.setMeta("publicKey", this.#wallet.publicKey());
+		}
+
+		if (this.#wallet.isCold() && transactions.some((t) => t.isSent() || t.isReturn())) {
+			this.#wallet.data().set(WalletData.Status, WalletFlag.Hot);
 		}
 
 		return transformConfirmedTransactionDataCollection(this.#wallet, result);

--- a/packages/profiles/source/transaction-index.ts
+++ b/packages/profiles/source/transaction-index.ts
@@ -59,11 +59,13 @@ export class TransactionIndex implements ITransactionIndex {
 	async #fetch(query: Services.ClientTransactionsInput): Promise<ExtendedConfirmedTransactionDataCollection> {
 		const result = await this.#wallet.getAttributes().get<Coins.Coin>("coin").client().transactions(query);
 
-		if (result.items().length > 0 && this.#wallet.isCold()) {
+		const transactions = result.items();
+
+		if (this.#wallet.isCold() && transactions.some((t) => t.isSent() || t.isReturn())) {
 			this.#wallet.data().set(WalletData.Status, WalletFlag.Hot);
 		}
 
-		for (const transaction of result.items()) {
+		for (const transaction of transactions) {
 			transaction.setMeta("address", this.#wallet.address());
 			transaction.setMeta("publicKey", this.#wallet.publicKey());
 		}

--- a/packages/profiles/source/transaction-index.ts
+++ b/packages/profiles/source/transaction-index.ts
@@ -59,11 +59,11 @@ export class TransactionIndex implements ITransactionIndex {
 	async #fetch(query: Services.ClientTransactionsInput): Promise<ExtendedConfirmedTransactionDataCollection> {
 		const result = await this.#wallet.getAttributes().get<Coins.Coin>("coin").client().transactions(query);
 
-		for (const transaction of result.items()) {
-			if (this.#wallet.isCold() && (transaction.isSent() || transaction.isReturn())) {
-				this.#wallet.data().set(WalletData.Status, WalletFlag.Hot);
-			}
+		if (result.items().length > 0 && this.#wallet.isCold()) {
+			this.#wallet.data().set(WalletData.Status, WalletFlag.Hot);
+		}
 
+		for (const transaction of result.items()) {
 			transaction.setMeta("address", this.#wallet.address());
 			transaction.setMeta("publicKey", this.#wallet.publicKey());
 		}


### PR DESCRIPTION
https://app.clickup.com/t/86dtjpcuz

The condition used to only apply to transactions that return `true` for `isSent` or `isConfirmed`. During my test, all transactions in my wallet returned false for both, which kept all my wallets as "cold." This was incorrect.

From my understanding, a wallet should be considered hot once it has any transaction, but it’s better to double-check.

