### PR TITLE
refactor: add public key generation

### DIFF
--- a/packages/profiles/source/wallet.factory.contract.ts
+++ b/packages/profiles/source/wallet.factory.contract.ts
@@ -12,6 +12,7 @@ export interface IGenerateOptions {
 	network: string;
 	locale?: string;
 	wordCount?: number;
+	withPublicKey?: boolean;
 }
 
 /**

--- a/packages/profiles/source/wallet.factory.ts
+++ b/packages/profiles/source/wallet.factory.ts
@@ -38,7 +38,7 @@ export class WalletFactory implements IWalletFactory {
 	}: IGenerateOptions): Promise<{ mnemonic: string; wallet: IReadWriteWallet }> {
 		const mnemonic: string = BIP39.generate(locale, wordCount);
 
-		const wallet =  await this.fromMnemonicWithBIP39({ coin, mnemonic, network });
+		const wallet = await this.fromMnemonicWithBIP39({ coin, mnemonic, network });
 
 		if (withPublicKey) {
 			const value = (await wallet.coin().publicKey().fromMnemonic(mnemonic)).publicKey;

--- a/packages/profiles/source/wallet.factory.ts
+++ b/packages/profiles/source/wallet.factory.ts
@@ -34,10 +34,18 @@ export class WalletFactory implements IWalletFactory {
 		network,
 		locale,
 		wordCount,
+		withPublicKey,
 	}: IGenerateOptions): Promise<{ mnemonic: string; wallet: IReadWriteWallet }> {
 		const mnemonic: string = BIP39.generate(locale, wordCount);
 
-		return { mnemonic, wallet: await this.fromMnemonicWithBIP39({ coin, mnemonic, network }) };
+		const wallet =  await this.fromMnemonicWithBIP39({ coin, mnemonic, network });
+
+		if (withPublicKey) {
+			const value = (await wallet.coin().publicKey().fromMnemonic(mnemonic)).publicKey;
+			wallet.data().set(WalletData.PublicKey, value);
+		}
+
+		return { mnemonic, wallet };
 	}
 
 	/** {@inheritDoc IWalletFactory.fromMnemonicWithBIP39} */


### PR DESCRIPTION
Closes: https://app.clickup.com/t/86dtr0w28

For testing:
- execute - `pnpm sdk:install-local ../platform-sdk/`
- replace this line in arkvault: https://github.com/ArdentHQ/arkvault/blob/693ed0a505b69069525a3011bf1270b77aedc790/src/app/hooks/use-fees.ts#L59

```
	const getWallet = useCallback(
		async (coin: string, network: string) => profile.walletFactory().generate({ coin, network, withPublicKey: true }),
		[profile],
	);
```

- try to make a musig tx with ARK network - you should have `fee` input populated