### PR TITLE
fix(ark): use correct type group on core & magistrate tx type filters

### DIFF
--- a/packages/ark/source/client.service.ts
+++ b/packages/ark/source/client.service.ts
@@ -305,9 +305,11 @@ export class ClientService extends Services.AbstractClientService {
 		}
 
 		if (Array.isArray(body.types)) {
-			const typeParameters = body.types.map((transactionType: string) => transactionTypeByName(transactionType)).filter(({ type }) => !!type)
-			const types = typeParameters.map(({ type }) => type).join(",")
-			const typeGroup = uniq(typeParameters.map(({ typeGroup }) => typeGroup)).join(",")
+			const typeParameters = body.types
+				.map((transactionType: string) => transactionTypeByName(transactionType))
+				.filter(({ type }) => !!type);
+			const types = typeParameters.map(({ type }) => type).join(",");
+			const typeGroup = uniq(typeParameters.map(({ typeGroup }) => typeGroup)).join(",");
 
 			if (types !== undefined) {
 				if (isLegacy) {

--- a/packages/ark/source/client.service.ts
+++ b/packages/ark/source/client.service.ts
@@ -1,4 +1,5 @@
 import { Collections, Contracts, IoC, Services } from "@ardenthq/sdk";
+import { uniq } from "@ardenthq/sdk-helpers";
 import { DateTime } from "@ardenthq/sdk-intl";
 import dotify from "node-dotify";
 
@@ -304,14 +305,9 @@ export class ClientService extends Services.AbstractClientService {
 		}
 
 		if (Array.isArray(body.types)) {
-			const { typeGroup } = transactionTypeByName(body.types.at(0));
-
-			const types = body.types
-				.map((transactionType: string) => {
-					const { type } = transactionTypeByName(transactionType);
-					return type;
-				})
-				.join(",");
+			const typeParameters = body.types.map((transactionType: string) => transactionTypeByName(transactionType)).filter(({ type }) => !!type)
+			const types = typeParameters.map(({ type }) => type).join(",")
+			const typeGroup = uniq(typeParameters.map(({ typeGroup }) => typeGroup)).join(",")
 
 			if (types !== undefined) {
 				if (isLegacy) {

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,10 +1,6 @@
 {
 	"name": "@ardenthq/sdk-helpers",
-<<<<<<< HEAD
 	"version": "2.1.0",
-=======
-	"version": "2.0.0",
->>>>>>> main
 	"description": "Cross-Platform Utilities for Ardent Applications",
 	"license": "MIT",
 	"contributors": [],


### PR DESCRIPTION
Related to https://app.clickup.com/t/86dunurq3

Fixes an issue where the typegroup is wrong when the filters have both core & magistrate transaction types.