### PR TITLE
feat: implement EVM validator resignation transaction

### DIFF
--- a/docs/profiles/wallets.md
+++ b/docs/profiles/wallets.md
@@ -337,6 +337,12 @@ await wallet.transaction().signMultiPayment(input, options);
 await wallet.transaction().signDelegateResignation(input, options);
 ```
 
+### Create a new validator resignation transaction
+
+```typescript
+await wallet.transaction().signValidatorResignation(input, options);
+```
+
 ### Create a new htlc lock transaction
 
 ```typescript

--- a/packages/mainsail/source/transaction.service.test.ts
+++ b/packages/mainsail/source/transaction.service.test.ts
@@ -70,6 +70,19 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 				}),
 			),
 		};
+
+		context.defaultValidatorResignationInput = {
+			fee: 1,
+			nonce: "1",
+			signatory: new Signatories.Signatory(
+				new Signatories.MnemonicSignatory({
+					address: identity.address,
+					privateKey: "privateKey",
+					publicKey: "publicKey",
+					signingKey: identity.mnemonic,
+				}),
+			),
+		};
 	});
 
 	it("should sign a transfer transaction", async (context) => {
@@ -145,6 +158,27 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 		} catch (error) {
 			assert.instance(error, Error);
 			assert.match(error.message, "Expected validatorPublicKey to be defined");
+		}
+	});
+
+	it("should sign a validator resignation transaction", async (context) => {
+		const signedTransaction = await context.subject.validatorResignation(
+			context.defaultValidatorResignationInput,
+		);
+
+		assert.is(signedTransaction.fee().toNumber(), context.defaultValidatorRegistrationInput.fee);
+		assert.is(signedTransaction.nonce().toString(), context.defaultValidatorRegistrationInput.nonce);
+	});
+
+	it("should require fee when signing a validator resignation transaction", async (context) => {
+		try {
+			await context.subject.validatorResignation({
+				...context.defaultValidatorResignationInput,
+				fee: undefined,
+			});
+		} catch (error) {
+			assert.instance(error, Error);
+			assert.match(error.message, "Expected fee to be defined");
 		}
 	});
 });

--- a/packages/mainsail/source/transaction.service.test.ts
+++ b/packages/mainsail/source/transaction.service.test.ts
@@ -162,9 +162,7 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 	});
 
 	it("should sign a validator resignation transaction", async (context) => {
-		const signedTransaction = await context.subject.validatorResignation(
-			context.defaultValidatorResignationInput,
-		);
+		const signedTransaction = await context.subject.validatorResignation(context.defaultValidatorResignationInput);
 
 		assert.is(signedTransaction.fee().toNumber(), context.defaultValidatorRegistrationInput.fee);
 		assert.is(signedTransaction.nonce().toString(), context.defaultValidatorRegistrationInput.nonce);

--- a/packages/mainsail/source/transaction.service.ts
+++ b/packages/mainsail/source/transaction.service.ts
@@ -28,10 +28,10 @@ interface ValidatedTransferInput extends Services.TransferInput {
 }
 
 type TransactionsInputs =
-	Services.TransferInput |
-	Services.VoteInput |
-	Services.ValidatorRegistrationInput |
-	Services.ValidatorResignationInput;
+	| Services.TransferInput
+	| Services.VoteInput
+	| Services.ValidatorRegistrationInput
+	| Services.ValidatorResignationInput;
 
 export class TransactionService extends Services.AbstractTransactionService {
 	readonly #ledgerService!: Services.LedgerService;

--- a/packages/mainsail/source/transaction.service.ts
+++ b/packages/mainsail/source/transaction.service.ts
@@ -20,6 +20,7 @@ const wellKnownContracts = {
 enum GasLimit {
 	Transfer = 21_000,
 	RegisterValidator = 500_000,
+	ResignValidator = 150_000,
 }
 
 interface ValidatedTransferInput extends Services.TransferInput {
@@ -168,10 +169,38 @@ export class TransactionService extends Services.AbstractTransactionService {
 		throw new Exceptions.NotImplemented(this.constructor.name, this.usernameResignation.name);
 	}
 
+	public override async validatorResignation(
+		input: Services.ValidatorResignationInput,
+	): Promise<Contracts.SignedTransactionData> {
+		applyCryptoConfiguration(this.#configCrypto);
+		this.#assertFee(input);
+
+		const transaction = this.#app.resolve(EvmCallBuilder);
+
+		const { address } = await this.#signerData(input);
+		const nonce = await this.#generateNonce(address, input);
+
+		const data = encodeFunctionData({
+			abi: ConsensusAbi.abi,
+			functionName: "resignValidator",
+			args: [],
+		});
+
+		transaction
+			.network(this.#configCrypto.crypto.network.pubKeyHash)
+			.gasLimit(GasLimit.ResignValidator)
+			.recipientAddress(wellKnownContracts.consensus)
+			.payload(data.slice(2))
+			.nonce(nonce)
+			.gasPrice(input.fee);
+
+		return this.#buildTransaction(input, transaction);
+	}
+
 	public override async delegateResignation(
 		input: Services.DelegateResignationInput,
 	): Promise<Contracts.SignedTransactionData> {
-		throw new Exceptions.NotImplemented(this.constructor.name, this.delegateResignation.name);
+		return this.validatorResignation(input);
 	}
 
 	public override async estimateExpiration(value?: string): Promise<string | undefined> {

--- a/packages/mainsail/source/transaction.service.ts
+++ b/packages/mainsail/source/transaction.service.ts
@@ -27,6 +27,12 @@ interface ValidatedTransferInput extends Services.TransferInput {
 	fee: number;
 }
 
+type TransactionsInputs =
+	Services.TransferInput |
+	Services.VoteInput |
+	Services.ValidatorRegistrationInput |
+	Services.ValidatorResignationInput;
+
 export class TransactionService extends Services.AbstractTransactionService {
 	readonly #ledgerService!: Services.LedgerService;
 	readonly #addressService!: Services.AddressService;
@@ -58,9 +64,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		);
 	}
 
-	#assertFee(
-		input: Services.TransferInput | Services.VoteInput | Services.ValidatorRegistrationInput,
-	): asserts input is ValidatedTransferInput {
+	#assertFee(input: TransactionsInputs): asserts input is ValidatedTransferInput {
 		if (!input.fee) {
 			throw new Error(
 				`[TransactionService#transfer] Expected fee to be defined but received ${typeof input.fee}`,

--- a/packages/profiles/source/wallet-transaction.service.contract.ts
+++ b/packages/profiles/source/wallet-transaction.service.contract.ts
@@ -139,11 +139,22 @@ export interface ITransactionService {
 	/**
 	 * Sign a Delegate Resignation transaction.
 	 *
+	 * @deprecated
+	 *
 	 * @param {Services.DelegateResignationInput} input
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
 	signDelegateResignation(input: Services.DelegateResignationInput): Promise<string>;
+
+	/**
+	 * Sign a Validator Resignation transaction.
+	 *
+	 * @param {Services.ValidatorResignationInput} input
+	 * @return {Promise<string>}
+	 * @memberof ITransactionService
+	 */
+	signValidatorResignation(input: Services.ValidatorResignationInput): Promise<string>;
 
 	/**
 	 * Sign an Unlock Token transaction.

--- a/packages/profiles/source/wallet-transaction.service.ts
+++ b/packages/profiles/source/wallet-transaction.service.ts
@@ -139,6 +139,11 @@ export class TransactionService implements ITransactionService {
 		return this.#signTransaction("delegateResignation", input);
 	}
 
+	/** {@inheritDoc ITransactionService.signValidatorResignation} */
+	public async signValidatorResignation(input: Services.ValidatorResignationInput): Promise<string> {
+		return this.#signTransaction("validatorResignation", input);
+	}
+
 	/** {@inheritDoc ITransactionService.signUnlockToken} */
 	public async signUnlockToken(input: Services.UnlockTokenInput): Promise<string> {
 		return this.#signTransaction("unlockToken", input);

--- a/packages/sdk/source/transaction.contract.ts
+++ b/packages/sdk/source/transaction.contract.ts
@@ -15,6 +15,7 @@ export interface TransactionService {
 	ipfs(input: IpfsInput): Promise<SignedTransactionData>;
 	multiPayment(input: MultiPaymentInput): Promise<SignedTransactionData>;
 	delegateResignation(input: DelegateResignationInput): Promise<SignedTransactionData>;
+	validatorResignation(input: ValidatorResignationInput): Promise<SignedTransactionData>;
 	unlockToken(input: UnlockTokenInput): Promise<SignedTransactionData>;
 
 	// Estimations
@@ -95,6 +96,7 @@ export interface MultiPaymentInput extends TransactionInput {
 }
 
 export type DelegateResignationInput = TransactionInput;
+export type ValidatorResignationInput = TransactionInput;
 
 export interface UnlockTokenInput extends TransactionInput {
 	data: {

--- a/packages/sdk/source/transaction.service.ts
+++ b/packages/sdk/source/transaction.service.ts
@@ -15,6 +15,7 @@ import {
 	UsernameResignationInput,
 	ValidatorRegistrationInput,
 	VoteInput,
+	ValidatorResignationInput,
 } from "./transaction.contract.js";
 
 import { BigNumberService } from "./big-number.service.js";
@@ -89,6 +90,10 @@ export class AbstractTransactionService implements Contract {
 
 	public async delegateResignation(input: DelegateResignationInput): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.delegateResignation.name);
+	}
+
+	public async validatorResignation(input: ValidatorResignationInput): Promise<SignedTransactionData> {
+		throw new NotImplemented(this.constructor.name, this.validatorResignation.name);
 	}
 
 	public async unlockToken(input: UnlockTokenInput): Promise<SignedTransactionData> {


### PR DESCRIPTION
Please review companion PR first: #124 

Continuation of: https://app.clickup.com/t/86dv1qa8g - resignation part

**Changelog:**
- implements validator resignation for Mainsail network by using EVM call
- deprecates existing `delegateResignation` method
- adds unit tests for the validator resignation

**In action:**

[Screencast from 2024-11-29 17-24-03.webm](https://github.com/user-attachments/assets/de71b784-19b2-45be-b472-7a8c26f23d9f)

