### PR TITLE
refactor: use empty string to identify transfer transactions

### DIFF
--- a/packages/mainsail/source/transaction-type.service.ts
+++ b/packages/mainsail/source/transaction-type.service.ts
@@ -17,7 +17,7 @@ export const trimHexPrefix = (type: string): string => {
 
 export class TransactionTypeService {
 	public static isTransfer(data: TransactionData): boolean {
-		return data.data === TransactionTypes.Transfer;
+		return data.data === "";
 	}
 
 	public static isSecondSignature(data: TransactionData): boolean {

--- a/packages/mainsail/source/transaction-type.service.ts
+++ b/packages/mainsail/source/transaction-type.service.ts
@@ -17,7 +17,7 @@ export const trimHexPrefix = (type: string): string => {
 
 export class TransactionTypeService {
 	public static isTransfer(data: TransactionData): boolean {
-		return data.data === "";
+		return data.data === TransactionTypes.Transfer;
 	}
 
 	public static isSecondSignature(data: TransactionData): boolean {

--- a/packages/mainsail/source/transaction-type.service.ts
+++ b/packages/mainsail/source/transaction-type.service.ts
@@ -7,7 +7,7 @@ export const TransactionTypes = {
 	MultiPayment: "0x88d695b2",
 	RegisterUsername: "0xusernamereg",
 	ResignUsername: "0xusernameres",
-	Transfer: "0x",
+	Transfer: "",
 	...FunctionSigs.ConsensusV1,
 } as const;
 


### PR DESCRIPTION
Closes: https://app.clickup.com/t/86dv9xhhq

This PR refactors `isTransfer` method to use an empty string to decide if a transaction is a transfer 