### PR TITLE
fix: remove unsupported types for signed transaction class

### DIFF
--- a/packages/sdk/source/signed-transaction.dto.ts
+++ b/packages/sdk/source/signed-transaction.dto.ts
@@ -22,17 +22,14 @@ export class AbstractSignedTransactionData implements SignedTransactionData {
 	readonly #types = {
 		delegateRegistration: "isDelegateRegistration",
 		delegateResignation: "isDelegateResignation",
-		htlcClaim: "isHtlcClaim",
-		htlcLock: "isHtlcLock",
-		htlcRefund: "isHtlcRefund",
 		ipfs: "isIpfs",
 		magistrate: "isMagistrate",
 		multiPayment: "isMultiPayment",
 		multiSignature: "isMultiSignatureRegistration",
 		secondSignature: "isSecondSignature",
 		transfer: "isTransfer",
-		usernameRegistration: "isUsernameRegistration",
 		unlockToken: "isUnlockToken",
+		usernameRegistration: "isUsernameRegistration",
 		usernameResignation: "isUsernameResignation",
 		unvote: "isUnvote",
 		validatorRegistration: "isValidatorRegistration",
@@ -81,6 +78,7 @@ export class AbstractSignedTransactionData implements SignedTransactionData {
 				continue;
 			}
 
+			console.log(type, method);
 			if (this[method]()) {
 				return type;
 			}

--- a/packages/sdk/source/signed-transaction.dto.ts
+++ b/packages/sdk/source/signed-transaction.dto.ts
@@ -78,7 +78,6 @@ export class AbstractSignedTransactionData implements SignedTransactionData {
 				continue;
 			}
 
-			console.log(type, method);
 			if (this[method]()) {
 				return type;
 			}


### PR DESCRIPTION
Closes: https://app.clickup.com/t/86dvcw560

I wanted to make `#types` in `ConfirmedTransactionData` and `SignedTransactionData` classes to be the same, however, there are some methods that are not implemented for the later, and it causes errors in some cases, that is why reverting the change.

https://github.com/ArdentHQ/platform-sdk/pull/134/files#diff-4013e06f07c9ccf0aa530bfb94a56d6bc1d3acce819b7342fec9b95a3d5dc14cR25