### PR TITLE
refactor: adjust helpers return type

### DIFF
--- a/packages/mainsail/source/confirmed-transaction.dto.ts
+++ b/packages/mainsail/source/confirmed-transaction.dto.ts
@@ -64,7 +64,7 @@ export class ConfirmedTransactionData extends DTO.AbstractConfirmedTransactionDa
 
 	public override fee(): BigNumber {
 		const gasPrice = this.bigNumberService.make(this.data.gasPrice);
-		return this.bigNumberService.make(parseUnits(gasPrice.times(this.data.gasLimit).toNumber(), "gwei"));
+		return parseUnits(gasPrice.times(this.data.gasLimit).toNumber(), "gwei");
 	}
 
 	public override asset(): Record<string, unknown> {

--- a/packages/mainsail/source/helpers/format-units.test.ts
+++ b/packages/mainsail/source/helpers/format-units.test.ts
@@ -4,15 +4,15 @@ import { formatUnits } from "./format-units";
 
 describe("formatUnits", async ({ assert, it }) => {
 	it("should format the value to wei", () => {
-		assert.equal(formatUnits("1", "wei"), "1");
+		assert.equal(formatUnits("1", "wei").valueOf(), "1");
 	});
 
 	it("should format the value to gwei", () => {
-		assert.equal(formatUnits("1000000000", "gwei"), "1");
+		assert.equal(formatUnits("1000000000", "gwei").valueOf(), "1");
 	});
 
 	it("should format the value to ark", () => {
-		assert.equal(formatUnits("1000000000000000000", "ark"), "1");
+		assert.equal(formatUnits("1000000000000000000", "ark").valueOf(), "1");
 	});
 
 	it("should throw an error for unsupported units", () => {

--- a/packages/mainsail/source/helpers/format-units.ts
+++ b/packages/mainsail/source/helpers/format-units.ts
@@ -2,14 +2,14 @@ import { BigNumber } from "@ardenthq/sdk-helpers";
 
 import { ARK_MULTIPLIER, GWEI_MULTIPLIER, WEI_MULTIPLIER } from "../crypto/constants";
 
-export const formatUnits = (value: string, unit = "ark"): string => {
+export const formatUnits = (value: string, unit = "ark"): BigNumber => {
 	switch (unit.toLowerCase()) {
 		case "wei":
-			return BigNumber.make(value).divide(WEI_MULTIPLIER).valueOf();
+			return BigNumber.make(value).divide(WEI_MULTIPLIER)
 		case "gwei":
-			return BigNumber.make(value).divide(GWEI_MULTIPLIER).valueOf();
+			return BigNumber.make(value).divide(GWEI_MULTIPLIER)
 		case "ark":
-			return BigNumber.make(value).divide(ARK_MULTIPLIER).valueOf();
+			return BigNumber.make(value).divide(ARK_MULTIPLIER)
 		default:
 			throw new Error(`Unsupported unit: ${unit}. Supported units are 'wei', 'gwei', and 'ark'.`);
 	}

--- a/packages/mainsail/source/helpers/format-units.ts
+++ b/packages/mainsail/source/helpers/format-units.ts
@@ -5,11 +5,11 @@ import { ARK_MULTIPLIER, GWEI_MULTIPLIER, WEI_MULTIPLIER } from "../crypto/const
 export const formatUnits = (value: string, unit = "ark"): BigNumber => {
 	switch (unit.toLowerCase()) {
 		case "wei":
-			return BigNumber.make(value).divide(WEI_MULTIPLIER)
+			return BigNumber.make(value).divide(WEI_MULTIPLIER);
 		case "gwei":
-			return BigNumber.make(value).divide(GWEI_MULTIPLIER)
+			return BigNumber.make(value).divide(GWEI_MULTIPLIER);
 		case "ark":
-			return BigNumber.make(value).divide(ARK_MULTIPLIER)
+			return BigNumber.make(value).divide(ARK_MULTIPLIER);
 		default:
 			throw new Error(`Unsupported unit: ${unit}. Supported units are 'wei', 'gwei', and 'ark'.`);
 	}

--- a/packages/mainsail/source/helpers/parse-units.test.ts
+++ b/packages/mainsail/source/helpers/parse-units.test.ts
@@ -4,15 +4,15 @@ import { parseUnits } from "./parse-units";
 
 describe("parseUnits", async ({ assert, it }) => {
 	it("should parse the value to wei", () => {
-		assert.equal(parseUnits(1, "wei"), "1");
+		assert.equal(parseUnits(1, "wei").valueOf(), "1");
 	});
 
 	it("should parse the value to gwei", () => {
-		assert.equal(parseUnits(1, "gwei"), "1000000000");
+		assert.equal(parseUnits(1, "gwei").valueOf(), "1000000000");
 	});
 
 	it("should parse the value to ark", () => {
-		assert.equal(parseUnits(1, "ark"), "1000000000000000000");
+		assert.equal(parseUnits(1, "ark").valueOf(), "1000000000000000000");
 	});
 
 	it("should throw an error for unsupported units", () => {

--- a/packages/mainsail/source/helpers/parse-units.ts
+++ b/packages/mainsail/source/helpers/parse-units.ts
@@ -2,14 +2,14 @@ import { BigNumber } from "@ardenthq/sdk-helpers";
 
 import { ARK_MULTIPLIER, GWEI_MULTIPLIER, WEI_MULTIPLIER } from "../crypto/constants";
 
-export const parseUnits = (value: number | string, unit = "ark"): string => {
+export const parseUnits = (value: number | string, unit = "ark"): BigNumber => {
 	switch (unit.toLowerCase()) {
 		case "wei":
-			return BigNumber.make(value).times(WEI_MULTIPLIER).valueOf();
+			return BigNumber.make(value).times(WEI_MULTIPLIER)
 		case "gwei":
-			return BigNumber.make(value).times(GWEI_MULTIPLIER).valueOf();
+			return BigNumber.make(value).times(GWEI_MULTIPLIER)
 		case "ark":
-			return BigNumber.make(value).times(ARK_MULTIPLIER).valueOf();
+			return BigNumber.make(value).times(ARK_MULTIPLIER)
 		default:
 			throw new Error(`Unsupported unit: ${unit}. Supported units are 'wei', 'gwei', and 'ark'.`);
 	}

--- a/packages/mainsail/source/helpers/parse-units.ts
+++ b/packages/mainsail/source/helpers/parse-units.ts
@@ -5,11 +5,11 @@ import { ARK_MULTIPLIER, GWEI_MULTIPLIER, WEI_MULTIPLIER } from "../crypto/const
 export const parseUnits = (value: number | string, unit = "ark"): BigNumber => {
 	switch (unit.toLowerCase()) {
 		case "wei":
-			return BigNumber.make(value).times(WEI_MULTIPLIER)
+			return BigNumber.make(value).times(WEI_MULTIPLIER);
 		case "gwei":
-			return BigNumber.make(value).times(GWEI_MULTIPLIER)
+			return BigNumber.make(value).times(GWEI_MULTIPLIER);
 		case "ark":
-			return BigNumber.make(value).times(ARK_MULTIPLIER)
+			return BigNumber.make(value).times(ARK_MULTIPLIER);
 		default:
 			throw new Error(`Unsupported unit: ${unit}. Supported units are 'wei', 'gwei', and 'ark'.`);
 	}

--- a/packages/mainsail/source/signed-transaction.dto.ts
+++ b/packages/mainsail/source/signed-transaction.dto.ts
@@ -44,7 +44,7 @@ export class SignedTransactionData
 
 	public override fee(): BigNumber {
 		const gasPrice = this.bigNumberService.make(this.signedData.gasPrice);
-		return this.bigNumberService.make(parseUnits(gasPrice.times(this.signedData.gasLimit).toNumber(), "gwei"));
+		return parseUnits(gasPrice.times(this.signedData.gasLimit).toNumber(), "gwei");
 	}
 
 	public override memo(): string | undefined {

--- a/packages/mainsail/source/transaction.service.test.ts
+++ b/packages/mainsail/source/transaction.service.test.ts
@@ -88,7 +88,10 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 	it("should sign a transfer transaction", async (context) => {
 		const signedTransaction = await context.subject.transfer(context.defaultTransferInput);
 
-		assert.is(signedTransaction.amount().toString(), parseUnits(context.defaultTransferInput.data.amount, "ark").valueOf());
+		assert.is(
+			signedTransaction.amount().toString(),
+			parseUnits(context.defaultTransferInput.data.amount, "ark").valueOf(),
+		);
 		assert.is(
 			signedTransaction.fee().toString(),
 			parseUnits(signedTransaction.signedData.gasLimit * signedTransaction.signedData.gasPrice, "gwei").valueOf(),

--- a/packages/mainsail/source/transaction.service.test.ts
+++ b/packages/mainsail/source/transaction.service.test.ts
@@ -88,10 +88,10 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 	it("should sign a transfer transaction", async (context) => {
 		const signedTransaction = await context.subject.transfer(context.defaultTransferInput);
 
-		assert.is(signedTransaction.amount().toString(), parseUnits(context.defaultTransferInput.data.amount, "ark"));
+		assert.is(signedTransaction.amount().toString(), parseUnits(context.defaultTransferInput.data.amount, "ark").valueOf());
 		assert.is(
 			signedTransaction.fee().toString(),
-			parseUnits(signedTransaction.signedData.gasLimit * signedTransaction.signedData.gasPrice, "gwei"),
+			parseUnits(signedTransaction.signedData.gasLimit * signedTransaction.signedData.gasPrice, "gwei").valueOf(),
 		);
 		assert.is(signedTransaction.nonce().toString(), context.defaultTransferInput.nonce);
 		assert.is(signedTransaction.recipient(), context.defaultTransferInput.data.to);
@@ -131,7 +131,7 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 
 		assert.is(
 			signedTransaction.fee().toString(),
-			parseUnits(signedTransaction.signedData.gasLimit * signedTransaction.signedData.gasPrice, "gwei"),
+			parseUnits(signedTransaction.signedData.gasLimit * signedTransaction.signedData.gasPrice, "gwei").valueOf(),
 		);
 		assert.is(signedTransaction.nonce().toString(), context.defaultValidatorRegistrationInput.nonce);
 
@@ -171,7 +171,7 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 
 		assert.is(
 			signedTransaction.fee().toString(),
-			parseUnits(signedTransaction.signedData.gasLimit * signedTransaction.signedData.gasPrice, "gwei"),
+			parseUnits(signedTransaction.signedData.gasLimit * signedTransaction.signedData.gasPrice, "gwei").valueOf(),
 		);
 		assert.is(signedTransaction.nonce().toString(), context.defaultValidatorRegistrationInput.nonce);
 	});

--- a/packages/mainsail/source/transaction.service.ts
+++ b/packages/mainsail/source/transaction.service.ts
@@ -94,7 +94,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 			.recipientAddress(input.data.to)
 			.payload("")
 			.nonce(nonce)
-			.value(parseUnits(input.data.amount, "ark"))
+			.value(parseUnits(input.data.amount, "ark").valueOf())
 			.gasPrice(input.fee);
 
 		return this.#buildTransaction(input, transaction);

--- a/packages/mainsail/source/transaction.service.votes.test.ts
+++ b/packages/mainsail/source/transaction.service.votes.test.ts
@@ -60,7 +60,7 @@ describe("TransactionService Votes", async ({ assert, beforeAll, nock, it }) => 
 		assert.is(signedTransaction.isUnvote(), false);
 		assert.is(
 			signedTransaction.fee().toString(),
-			parseUnits(signedTransaction.signedData.gasLimit * signedTransaction.signedData.gasPrice, "gwei"),
+			parseUnits(signedTransaction.signedData.gasLimit * signedTransaction.signedData.gasPrice, "gwei").valueOf(),
 		);
 		assert.is(signedTransaction.nonce().toString(), context.defaultInput.nonce);
 	});
@@ -75,7 +75,7 @@ describe("TransactionService Votes", async ({ assert, beforeAll, nock, it }) => 
 		assert.is(signedTransaction.isVote(), false);
 		assert.is(
 			signedTransaction.fee().toString(),
-			parseUnits(signedTransaction.signedData.gasLimit * signedTransaction.signedData.gasPrice, "gwei"),
+			parseUnits(signedTransaction.signedData.gasLimit * signedTransaction.signedData.gasPrice, "gwei").valueOf(),
 		);
 		assert.is(signedTransaction.nonce().toString(), context.defaultInput.nonce);
 	});


### PR DESCRIPTION
# [[psdk] adjust parseUnits and formatUnits return type](https://app.clickup.com/t/86dvkw98m)

## What's new?

- The following helpers: `formatUnits` and `parseUnits`, have been refactored to return the `BigNumber` instead of a string or a number.
- Implementations of these methods have been refactored.
- Unit tests have also been refactored to support this change.