### PR TITLE
refactor: use `gasPrice` and `gasLimit` for transactions

### DIFF
--- a/packages/mainsail/source/fee.service.ts
+++ b/packages/mainsail/source/fee.service.ts
@@ -58,11 +58,11 @@ export class FeeService extends Services.AbstractFeeService {
 
 	#transform(dynamicFees: Fees): Services.TransactionFee {
 		return {
-			avg: BigNumber.make(dynamicFees?.avg ?? "0").divide(GWEI_MULTIPLIER),
+			avg: BigNumber.make(dynamicFees?.avg ?? "0"),
 			isDynamic: true,
-			max: BigNumber.make(dynamicFees?.max ?? "0").divide(GWEI_MULTIPLIER),
-			min: BigNumber.make(dynamicFees?.min ?? "0").divide(GWEI_MULTIPLIER),
-			static: BigNumber.make("0").divide(GWEI_MULTIPLIER),
+			max: BigNumber.make(dynamicFees?.max ?? "0"),
+			min: BigNumber.make(dynamicFees?.min ?? "0"),
+			static: BigNumber.make("0"),
 		};
 	}
 }

--- a/packages/mainsail/source/transaction.service.test.ts
+++ b/packages/mainsail/source/transaction.service.test.ts
@@ -42,7 +42,8 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 				memo: "foo",
 				to: identity.address,
 			},
-			fee: 1,
+			gasLimit: 21_000,
+			gasPrice: 5,
 			nonce: "1",
 			signatory: new Signatories.Signatory(
 				new Signatories.MnemonicSignatory({

--- a/packages/mainsail/source/transaction.service.test.ts
+++ b/packages/mainsail/source/transaction.service.test.ts
@@ -60,7 +60,8 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 				validatorPublicKey:
 					"8e65659ba176f2e14e9042db662c6106a85ecd6ec8de14665facc4aaa643aec0c2d0a7ea29cecd7daf5b6452e39d431d",
 			},
-			fee: 1,
+			gasLimit: 500_000,
+			gasPrice: 5,
 			nonce: "1",
 			signatory: new Signatories.Signatory(
 				new Signatories.MnemonicSignatory({
@@ -73,7 +74,8 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 		};
 
 		context.defaultValidatorResignationInput = {
-			fee: 1,
+			gasLimit: 150_000,
+			gasPrice: 5,
 			nonce: "1",
 			signatory: new Signatories.Signatory(
 				new Signatories.MnemonicSignatory({
@@ -101,15 +103,27 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 		assert.is(signedTransaction.recipient(), context.defaultTransferInput.data.to);
 	});
 
-	it("should require fee when signing a transfer transaction", async (context) => {
+	it("should require gasFee when signing a transfer transaction", async (context) => {
 		try {
 			await context.subject.transfer({
 				...context.defaultTransferInput,
-				fee: null,
+				gasFee: undefined,
 			});
 		} catch (error) {
 			assert.instance(error, Error);
-			assert.match(error.message, "Expected fee to be defined");
+			assert.match(error.message, "Expected gasFee to be defined");
+		}
+	});
+
+	it("should require gasPrice when signing a transfer transaction", async (context) => {
+		try {
+			await context.subject.transfer({
+				...context.defaultTransferInput,
+				gasPrice: undefined,
+			});
+		} catch (error) {
+			assert.instance(error, Error);
+			assert.match(error.message, "Expected gasPrice to be defined");
 		}
 	});
 
@@ -144,15 +158,27 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 		assert.match(signedTransaction.data().data, validatorKey);
 	});
 
-	it("should require fee when signing a validator registration transaction", async (context) => {
+	it("should require gasPrice when signing a validator registration transaction", async (context) => {
 		try {
 			await context.subject.validatorRegistration({
 				...context.defaultValidatorRegistrationInput,
-				fee: undefined,
+				gasPrice: undefined,
 			});
 		} catch (error) {
 			assert.instance(error, Error);
-			assert.match(error.message, "Expected fee to be defined");
+			assert.match(error.message, "Expected gasPrice to be defined");
+		}
+	});
+
+	it("should require gasLimit when signing a validator registration transaction", async (context) => {
+		try {
+			await context.subject.validatorRegistration({
+				...context.defaultValidatorRegistrationInput,
+				gasLimit: undefined,
+			});
+		} catch (error) {
+			assert.instance(error, Error);
+			assert.match(error.message, "Expected gasLimit to be defined");
 		}
 	});
 
@@ -180,15 +206,27 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 		assert.is(signedTransaction.nonce().toString(), context.defaultValidatorRegistrationInput.nonce);
 	});
 
-	it("should require fee when signing a validator resignation transaction", async (context) => {
+	it("should require gasPrice when signing a validator resignation transaction", async (context) => {
 		try {
 			await context.subject.validatorResignation({
 				...context.defaultValidatorResignationInput,
-				fee: undefined,
+				gasPrice: undefined,
 			});
 		} catch (error) {
 			assert.instance(error, Error);
-			assert.match(error.message, "Expected fee to be defined");
+			assert.match(error.message, "Expected gasPrice to be defined");
+		}
+	});
+
+	it("should require gasLimit when signing a validator resignation transaction", async (context) => {
+		try {
+			await context.subject.validatorResignation({
+				...context.defaultValidatorResignationInput,
+				gasLimit: undefined,
+			});
+		} catch (error) {
+			assert.instance(error, Error);
+			assert.match(error.message, "Expected gasLimit to be defined");
 		}
 	});
 });

--- a/packages/mainsail/source/transaction.service.ts
+++ b/packages/mainsail/source/transaction.service.ts
@@ -109,7 +109,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 		transaction
 			.network(this.#configCrypto.crypto.network.pubKeyHash)
-			.gasLimit(input.gasLimit ?? GasLimit.Transfer)
+			.gasLimit(input.gasLimit)
 			.recipientAddress(input.data.to)
 			.payload("")
 			.nonce(nonce)

--- a/packages/mainsail/source/transaction.service.ts
+++ b/packages/mainsail/source/transaction.service.ts
@@ -24,10 +24,6 @@ enum GasLimit {
 }
 
 interface ValidatedTransferInput extends Services.TransferInput {
-	fee: number;
-}
-
-interface ValidatedTransferInput2 extends Services.TransferInput {
 	gasPrice: number;
 	gasLimit: number;
 }
@@ -67,7 +63,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		);
 	}
 
-	#assertGasPriceAndLimit(input: TransactionsInputs): asserts input is ValidatedTransferInput2 {
+	#assertGasFee(input: TransactionsInputs): asserts input is ValidatedTransferInput {
 		if (!input.gasPrice) {
 			throw new Error(
 				`[TransactionService#transfer] Expected gasPrice to be defined but received ${typeof input.gasPrice}`,
@@ -77,14 +73,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 		if (!input.gasLimit) {
 			throw new Error(
 				`[TransactionService#transfer] Expected gasLimit to be defined but received ${typeof input.gasLimit}`,
-			);
-		}
-	}
-
-	#assertFee(input: TransactionsInputs): asserts input is ValidatedTransferInput {
-		if (!input.fee) {
-			throw new Error(
-				`[TransactionService#transfer] Expected fee to be defined but received ${typeof input.fee}`,
 			);
 		}
 	}
@@ -99,7 +87,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public override async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		applyCryptoConfiguration(this.#configCrypto);
-		this.#assertGasPriceAndLimit(input);
+		this.#assertGasFee(input);
 		this.#assertAmount(input);
 
 		const transaction = this.#app.resolve(EvmCallBuilder);
@@ -123,7 +111,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		input: Services.ValidatorRegistrationInput,
 	): Promise<Contracts.SignedTransactionData> {
 		applyCryptoConfiguration(this.#configCrypto);
-		this.#assertFee(input);
+		this.#assertGasFee(input);
 
 		if (!input.data.validatorPublicKey) {
 			throw new Error(
@@ -145,11 +133,11 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 		transaction
 			.network(this.#configCrypto.crypto.network.pubKeyHash)
-			.gasLimit(GasLimit.RegisterValidator)
+			.gasLimit(input.gasLimit)
 			.recipientAddress(wellKnownContracts.consensus)
 			.payload(data.slice(2))
 			.nonce(nonce)
-			.gasPrice(input.fee);
+			.gasPrice(input.gasPrice);
 
 		return this.#buildTransaction(input, transaction);
 	}
@@ -165,7 +153,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	 */
 	public override async vote(input: Services.VoteInput): Promise<Contracts.SignedTransactionData> {
 		applyCryptoConfiguration(this.#configCrypto);
-		this.#assertFee(input);
+		this.#assertGasFee(input);
 
 		const transaction = this.#app.resolve(EvmCallBuilder);
 
@@ -184,10 +172,10 @@ export class TransactionService extends Services.AbstractTransactionService {
 		transaction
 			.network(this.#configCrypto.crypto.network.pubKeyHash)
 			.recipientAddress(wellKnownContracts.consensus)
-			.gasLimit(GasLimit.Vote)
+			.gasLimit(input.gasLimit)
 			.payload(data.slice(2))
 			.nonce(nonce)
-			.gasPrice(input.fee);
+			.gasPrice(input.gasPrice);
 
 		return this.#buildTransaction(input, transaction);
 	}
@@ -215,7 +203,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		input: Services.ValidatorResignationInput,
 	): Promise<Contracts.SignedTransactionData> {
 		applyCryptoConfiguration(this.#configCrypto);
-		this.#assertFee(input);
+		this.#assertGasFee(input);
 
 		const transaction = this.#app.resolve(EvmCallBuilder);
 
@@ -230,11 +218,11 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 		transaction
 			.network(this.#configCrypto.crypto.network.pubKeyHash)
-			.gasLimit(GasLimit.ResignValidator)
+			.gasLimit(input.gasLimit)
 			.recipientAddress(wellKnownContracts.consensus)
 			.payload(data.slice(2))
 			.nonce(nonce)
-			.gasPrice(input.fee);
+			.gasPrice(input.gasPrice);
 
 		return this.#buildTransaction(input, transaction);
 	}

--- a/packages/mainsail/source/transaction.service.ts
+++ b/packages/mainsail/source/transaction.service.ts
@@ -24,7 +24,8 @@ enum GasLimit {
 }
 
 interface ValidatedTransferInput extends Services.TransferInput {
-	fee: number;
+	gasPrice: number;
+	gasLimit: number;
 }
 
 type TransactionsInputs =
@@ -63,9 +64,15 @@ export class TransactionService extends Services.AbstractTransactionService {
 	}
 
 	#assertFee(input: TransactionsInputs): asserts input is ValidatedTransferInput {
-		if (!input.fee) {
+		if (!input.gasPrice) {
 			throw new Error(
-				`[TransactionService#transfer] Expected fee to be defined but received ${typeof input.fee}`,
+				`[TransactionService#transfer] Expected gasPrice to be defined but received ${typeof input.gasPrice}`,
+			);
+		}
+
+		if (!input.gasLimit) {
+			throw new Error(
+				`[TransactionService#transfer] Expected gasLimit to be defined but received ${typeof input.gasLimit}`,
 			);
 		}
 	}
@@ -90,12 +97,12 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 		transaction
 			.network(this.#configCrypto.crypto.network.pubKeyHash)
-			.gasLimit(GasLimit.Transfer)
+			.gasLimit(input.gasLimit ?? GasLimit.Transfer)
 			.recipientAddress(input.data.to)
 			.payload("")
 			.nonce(nonce)
 			.value(parseUnits(input.data.amount, "ark").valueOf())
-			.gasPrice(input.fee);
+			.gasPrice(input.gasPrice);
 
 		return this.#buildTransaction(input, transaction);
 	}

--- a/packages/mainsail/source/transaction.service.ts
+++ b/packages/mainsail/source/transaction.service.ts
@@ -24,6 +24,10 @@ enum GasLimit {
 }
 
 interface ValidatedTransferInput extends Services.TransferInput {
+	fee: number;
+}
+
+interface ValidatedTransferInput2 extends Services.TransferInput {
 	gasPrice: number;
 	gasLimit: number;
 }
@@ -63,7 +67,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		);
 	}
 
-	#assertFee(input: TransactionsInputs): asserts input is ValidatedTransferInput {
+	#assertGasPriceAndLimit(input: TransactionsInputs): asserts input is ValidatedTransferInput2 {
 		if (!input.gasPrice) {
 			throw new Error(
 				`[TransactionService#transfer] Expected gasPrice to be defined but received ${typeof input.gasPrice}`,
@@ -73,6 +77,14 @@ export class TransactionService extends Services.AbstractTransactionService {
 		if (!input.gasLimit) {
 			throw new Error(
 				`[TransactionService#transfer] Expected gasLimit to be defined but received ${typeof input.gasLimit}`,
+			);
+		}
+	}
+
+	#assertFee(input: TransactionsInputs): asserts input is ValidatedTransferInput {
+		if (!input.fee) {
+			throw new Error(
+				`[TransactionService#transfer] Expected fee to be defined but received ${typeof input.fee}`,
 			);
 		}
 	}
@@ -87,7 +99,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public override async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		applyCryptoConfiguration(this.#configCrypto);
-		this.#assertFee(input);
+		this.#assertGasPriceAndLimit(input);
 		this.#assertAmount(input);
 
 		const transaction = this.#app.resolve(EvmCallBuilder);

--- a/packages/mainsail/source/transaction.service.votes.test.ts
+++ b/packages/mainsail/source/transaction.service.votes.test.ts
@@ -97,7 +97,7 @@ describe("TransactionService Votes", async ({ assert, beforeAll, nock, it }) => 
 		try {
 			await context.subject.vote({
 				...context.defaultInput,
-				gasLimit : undefined,
+				gasLimit: undefined,
 			});
 		} catch (error) {
 			assert.instance(error, Error);

--- a/packages/mainsail/source/transaction.service.votes.test.ts
+++ b/packages/mainsail/source/transaction.service.votes.test.ts
@@ -40,7 +40,8 @@ describe("TransactionService Votes", async ({ assert, beforeAll, nock, it }) => 
 			data: {
 				votes: [{ amount: 0, id: identity.address }],
 			},
-			fee: 5,
+			gasLimit: 200_000,
+			gasPrice: 5,
 			nonce: "1",
 			signatory: new Signatories.Signatory(
 				new Signatories.MnemonicSignatory({
@@ -80,15 +81,27 @@ describe("TransactionService Votes", async ({ assert, beforeAll, nock, it }) => 
 		assert.is(signedTransaction.nonce().toString(), context.defaultInput.nonce);
 	});
 
-	it("should require fee when signing transaction", async (context) => {
+	it("should require gasPrice when signing transaction", async (context) => {
 		try {
-			const signedTransaction = await context.subject.vote({
+			await context.subject.vote({
 				...context.defaultInput,
-				fee: null,
+				gasPrice: undefined,
 			});
 		} catch (error) {
 			assert.instance(error, Error);
-			assert.match(error.message, "Expected fee to be defined");
+			assert.match(error.message, "Expected gasPrice to be defined");
+		}
+	});
+
+	it("should require gasLimit when signing transaction", async (context) => {
+		try {
+			await context.subject.vote({
+				...context.defaultInput,
+				gasLimit : undefined,
+			});
+		} catch (error) {
+			assert.instance(error, Error);
+			assert.match(error.message, "Expected gasLimit to be defined");
 		}
 	});
 });

--- a/packages/sdk/source/transaction.contract.ts
+++ b/packages/sdk/source/transaction.contract.ts
@@ -24,8 +24,8 @@ export interface TransactionService {
 
 // Transaction Signing
 export interface TransactionInput {
-	fee?: number;
-	feeLimit?: number;
+	gasPrice?: number;
+	gasLimit?: number;
 	nonce?: string;
 	signatory: Signatory;
 	contract?: {

--- a/packages/sdk/source/transaction.contract.ts
+++ b/packages/sdk/source/transaction.contract.ts
@@ -24,6 +24,8 @@ export interface TransactionService {
 
 // Transaction Signing
 export interface TransactionInput {
+	fee?: number;
+	feeLimit?: number;
 	gasPrice?: number;
 	gasLimit?: number;
 	nonce?: string;


### PR DESCRIPTION
As a part of https://app.clickup.com/t/86dvn14ac

Companion PR: https://github.com/ArdentHQ/arkvault/pull/884

This PR refactors logic to use `gasLimit` and `gasPrice` values when sending transfer transactions. 

Note: I had to duplicate some parts as the remaining transaction types are still using old `fee` property.