### PR TITLE
refactor: remove network from contact repository

### DIFF
--- a/packages/profiles/source/contact-address.contract.ts
+++ b/packages/profiles/source/contact-address.contract.ts
@@ -6,7 +6,6 @@
  */
 export interface IContactAddressInput {
 	coin: string;
-	network: string;
 	address: string;
 }
 
@@ -19,7 +18,6 @@ export interface IContactAddressInput {
 export interface IContactAddressData {
 	id: string;
 	coin: string;
-	network: string;
 	address: string;
 }
 
@@ -45,14 +43,6 @@ export interface IContactAddress {
 	 * @memberof IContactAddress
 	 */
 	coin(): string;
-
-	/**
-	 *
-	 *
-	 * @returns {string}
-	 * @memberof IContactAddress
-	 */
-	network(): string;
 
 	/**
 	 *

--- a/packages/profiles/source/contact-address.repository.contract.ts
+++ b/packages/profiles/source/contact-address.repository.contract.ts
@@ -93,16 +93,7 @@ export interface IContactAddressRepository {
 	findByCoin(value: string): IContactAddress[];
 
 	/**
-	 * Find many contact addresses by their network.
-	 *
-	 * @param {string} value
-	 * @returns {IContactAddress[]}
-	 * @memberof IContactAddressRepository
-	 */
-	findByNetwork(value: string): IContactAddress[];
-
-	/**
-	 * Check if an item exists with the same network, coin, and address.
+	 * Check if an item exists with the same coin, and address.
 	 *
 	 * @param {IContactAddressInput} value
 	 * @return {boolean}

--- a/packages/profiles/source/contact-address.repository.test.ts
+++ b/packages/profiles/source/contact-address.repository.test.ts
@@ -11,7 +11,6 @@ void describeWithContext(
 		stubData: {
 			address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
 			coin: "ARK",
-			network: "ark.devnet",
 		},
 	},
 	async ({ it, beforeEach, assert }) => {
@@ -128,13 +127,6 @@ void describeWithContext(
 			assert.length(context.subject.findByCoin("invalid"), 0);
 		});
 
-		it("#findByNetwork", (context) => {
-			const address = context.subject.create(context.stubData);
-
-			assert.length(context.subject.findByNetwork(address.network()), 1);
-			assert.length(context.subject.findByNetwork("invalid"), 0);
-		});
-
 		it("#flush", (context) => {
 			context.subject.create(context.stubData);
 
@@ -154,7 +146,6 @@ void describeWithContext(
 				context.subject.exists({
 					address: "DAWdHfDFEvvu57cHjAhs5K5di33B2DdCu1",
 					coin: "ARK",
-					network: "ark.devnet",
 				}),
 			);
 		});

--- a/packages/profiles/source/contact-address.repository.ts
+++ b/packages/profiles/source/contact-address.repository.ts
@@ -84,17 +84,12 @@ export class ContactAddressRepository implements IContactAddressRepository {
 		return this.#findByColumn("coin", value);
 	}
 
-	/** {@inheritDoc IContactAddressRepository.findByNetwork} */
-	public findByNetwork(value: string): IContactAddress[] {
-		return this.#findByColumn("network", value);
-	}
-
 	/** {@inheritDoc IContactAddressRepository.exists} */
-	public exists({ address, coin, network }: IContactAddressInput): boolean {
-		const value = [address, coin, network].join("");
+	public exists({ address, coin }: IContactAddressInput): boolean {
+		const value = [address, coin].join("");
 
 		for (const item of this.values()) {
-			const compareValue = [item.address(), item.coin(), item.network()].join("");
+			const compareValue = [item.address(), item.coin()].join("");
 
 			if (value === compareValue) {
 				return true;

--- a/packages/profiles/source/contact-address.test.ts
+++ b/packages/profiles/source/contact-address.test.ts
@@ -15,7 +15,6 @@ describe("ContactAddress", async ({ it, assert, beforeEach }) => {
 				address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
 				coin: "ARK",
 				id: "uuid",
-				network: "ark.devnet",
 			},
 			profile,
 		);
@@ -27,10 +26,6 @@ describe("ContactAddress", async ({ it, assert, beforeEach }) => {
 
 	it("should have a coin", (context) => {
 		assert.is(context.subject.coin(), "ARK");
-	});
-
-	it("should have a network", (context) => {
-		assert.is(context.subject.network(), "ark.devnet");
 	});
 
 	it("should have an address", (context) => {
@@ -46,7 +41,6 @@ describe("ContactAddress", async ({ it, assert, beforeEach }) => {
 			address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
 			coin: "ARK",
 			id: "uuid",
-			network: "ark.devnet",
 		});
 	});
 

--- a/packages/profiles/source/contact-address.ts
+++ b/packages/profiles/source/contact-address.ts
@@ -20,11 +20,6 @@ export class ContactAddress implements IContactAddress {
 		return this.#data.coin;
 	}
 
-	/** {@inheritDoc IContactAddress.network} */
-	public network(): string {
-		return this.#data.network;
-	}
-
 	/** {@inheritDoc IContactAddress.address} */
 	public address(): string {
 		return this.#data.address;
@@ -41,7 +36,6 @@ export class ContactAddress implements IContactAddress {
 			address: this.address(),
 			coin: this.coin(),
 			id: this.id(),
-			network: this.network(),
 		};
 	}
 

--- a/packages/profiles/source/contact.repository.contract.ts
+++ b/packages/profiles/source/contact.repository.contract.ts
@@ -126,15 +126,6 @@ export interface IContactRepository {
 	findByCoin(value: string): IContact[];
 
 	/**
-	 * Find many contacts by their network.
-	 *
-	 * @param {string} value
-	 * @returns {IContact[]}
-	 * @memberof IContactRepository
-	 */
-	findByNetwork(value: string): IContact[];
-
-	/**
 	 * Turn the contacts into a normalised object.
 	 *
 	 * @returns {Record<string, IContactData>}

--- a/packages/profiles/source/contact.repository.test.ts
+++ b/packages/profiles/source/contact.repository.test.ts
@@ -7,8 +7,8 @@ import { Profile } from "./profile";
 void describeWithContext(
 	"ContactRepository",
 	{
-		addr: { address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW", coin: "ARK", network: "ark.devnet" },
-		addr2: { address: "DAWdHfDFEvvu57cHjAhs5K5di33B2DdCu1", coin: "ARK", network: "ark.devnet" },
+		addr: { address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW", coin: "ARK" },
+		addr2: { address: "DAWdHfDFEvvu57cHjAhs5K5di33B2DdCu1", coin: "ARK" },
 		name: "John Doe",
 	},
 	async ({ beforeEach, it, assert }) => {
@@ -63,8 +63,7 @@ void describeWithContext(
 					context.subject.create("InvalidAddress", [
 						{
 							address: undefined,
-							coin: "ARK",
-							network: "ark.devnet",
+							coin: "ARK"
 						},
 					]),
 				'addresses[0].address" is required',
@@ -78,24 +77,9 @@ void describeWithContext(
 						{
 							address: "a",
 							coin: undefined,
-							network: "ark.devnet",
 						},
 					]),
 				'addresses[0].coin" is required',
-			);
-
-			assert.is(context.subject.count(), 1);
-
-			assert.throws(
-				() =>
-					context.subject.create("InvalidAddress", [
-						{
-							address: "a",
-							coin: "ARK",
-							network: undefined,
-						},
-					]),
-				'addresses[0].network" is required',
 			);
 
 			assert.is(context.subject.count(), 1);
@@ -167,13 +151,6 @@ void describeWithContext(
 
 			assert.length(context.subject.findByCoin(context.addr.coin), 1);
 			assert.length(context.subject.findByCoin("invalid"), 0);
-		});
-
-		it("#findByNetwork", (context) => {
-			context.subject.create(context.name, [context.addr]);
-
-			assert.length(context.subject.findByNetwork(context.addr.network), 1);
-			assert.length(context.subject.findByNetwork("invalid"), 0);
 		});
 
 		it("#flush", (context) => {

--- a/packages/profiles/source/contact.repository.ts
+++ b/packages/profiles/source/contact.repository.ts
@@ -138,11 +138,6 @@ export class ContactRepository implements IContactRepository {
 		return this.#findByColumn("coin", value);
 	}
 
-	/** {@inheritDoc IContactRepository.findByNetwork} */
-	public findByNetwork(value: string): IContact[] {
-		return this.#findByColumn("network", value);
-	}
-
 	/** {@inheritDoc IContactRepository.toObject} */
 	public toObject(): Record<string, IContactData> {
 		const result: Record<string, IContactData> = {};

--- a/packages/profiles/source/contact.test.ts
+++ b/packages/profiles/source/contact.test.ts
@@ -68,7 +68,6 @@ describe("Contact", ({ assert, it, beforeEach }) => {
 			{
 				address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
 				coin: "ARK",
-				network: "ark.devnet",
 			},
 		]);
 

--- a/packages/profiles/source/contact.ts
+++ b/packages/profiles/source/contact.ts
@@ -111,3 +111,4 @@ export class Contact implements IContact {
 		}
 	}
 }
+

--- a/packages/profiles/source/contact.ts
+++ b/packages/profiles/source/contact.ts
@@ -111,4 +111,3 @@ export class Contact implements IContact {
 		}
 	}
 }
-

--- a/packages/profiles/source/contact.ts
+++ b/packages/profiles/source/contact.ts
@@ -98,8 +98,7 @@ export class Contact implements IContact {
 				.items(
 					Joi.object({
 						address: Joi.string().required(),
-						coin: Joi.string().required(),
-						network: Joi.string().required(),
+						coin: Joi.string().required()
 					}),
 				),
 			id: Joi.string().required(),


### PR DESCRIPTION
# [[contacts] remove network](https://app.clickup.com/t/86dvxqpcb)

## Description

- `Network` has been removed from `Contact` as a required property.
- Methods related to searching contacts by the network and other related methods have also been refactored to support this change.
- Unit tests have been refactored to remove the use of network in them.