### PR TITLE
refactor: handle multipayment transactions

### DIFF
--- a/packages/ark/source/signed-transaction.dto.ts
+++ b/packages/ark/source/signed-transaction.dto.ts
@@ -2,6 +2,7 @@ import { Contracts, DTO } from "@ardenthq/sdk";
 import { BigNumber } from "@ardenthq/sdk-helpers";
 import { DateTime } from "@ardenthq/sdk-intl";
 
+import { MultiPaymentItem } from "@ardenthq/sdk/source/confirmed-transaction.dto.contract.js";
 import { Identities } from "./crypto/index.js";
 import { TransactionTypeService } from "./transaction-type.service.js";
 
@@ -25,6 +26,13 @@ export class SignedTransactionData
 		}
 
 		return this.bigNumberService.make(this.signedData.amount);
+	}
+
+	public override payments(): MultiPaymentItem[] {
+		return this.signedData.asset.payments.map((payment: MultiPaymentItem) => ({
+			address: payment.recipientId,
+			amount: this.bigNumberService.make(payment.amount),
+		}));
 	}
 
 	public override fee(): BigNumber {

--- a/packages/mainsail/source/confirmed-transaction.dto.ts
+++ b/packages/mainsail/source/confirmed-transaction.dto.ts
@@ -6,6 +6,7 @@ import { BindingType } from "./coin.contract.js";
 import { AbiType, decodeFunctionData } from "./helpers/decode-function-data.js";
 import { TransactionTypeService } from "./transaction-type.service.js";
 import { formatUnits } from "./helpers/format-units";
+import { MultiPaymentItem } from "@ardenthq/sdk/source/confirmed-transaction.dto.contract";
 
 export class ConfirmedTransactionData extends DTO.AbstractConfirmedTransactionData {
 	readonly #addressService: Services.AddressService;
@@ -190,8 +191,8 @@ export class ConfirmedTransactionData extends DTO.AbstractConfirmedTransactionDa
 	}
 
 	// Multi-Payment
-	public override payments(): { recipientId: string; amount: BigNumber }[] {
-		const payments: { recipientId: string; amount: BigNumber }[] = [];
+	public override payments(): MultiPaymentItem[] {
+		const payments: MultiPaymentItem[] = [];
 
 		const [recipients, amounts] = decodeFunctionData(this.data.data, AbiType.MultiPayment).args;
 

--- a/packages/mainsail/source/confirmed-transaction.dto.ts
+++ b/packages/mainsail/source/confirmed-transaction.dto.ts
@@ -3,8 +3,7 @@ import { BigNumber } from "@ardenthq/sdk-helpers";
 import { DateTime } from "@ardenthq/sdk-intl";
 
 import { BindingType } from "./coin.contract.js";
-import { decodeFunctionData } from "./helpers/decode-function-data.js";
-import { parseUnits } from "./helpers/parse-units.js";
+import { AbiType, decodeFunctionData } from "./helpers/decode-function-data.js";
 import { TransactionTypeService } from "./transaction-type.service.js";
 import { formatUnits } from "./helpers/format-units";
 
@@ -50,15 +49,18 @@ export class ConfirmedTransactionData extends DTO.AbstractConfirmedTransactionDa
 			return [];
 		}
 
-		return this.data.asset.payments.map((payment: { recipientId: string; amount: BigNumber }) => ({
-			address: payment.recipientId,
-			amount: this.bigNumberService.make(payment.amount),
-		}));
+		return this.payments().map((payment) => {
+			return {
+				address: payment.recipientId,
+				amount: payment.amount,
+			};
+		});
 	}
 
 	public override amount(): BigNumber {
-		// @TODO: handle evm multipayments.
-		// if (this.isMultiPayment()) { }
+		if (this.isMultiPayment()) {
+			return BigNumber.sum(this.payments().map(({ amount }) => amount));
+		}
 
 		return this.bigNumberService.make(this.data.amount);
 	}
@@ -150,7 +152,7 @@ export class ConfirmedTransactionData extends DTO.AbstractConfirmedTransactionDa
 
 	// Username registration
 	public override username(): string {
-		return decodeFunctionData(this.data.data, "username").args[0] as string;
+		return decodeFunctionData(this.data.data, AbiType.Username).args[0] as string;
 	}
 
 	public override validatorPublicKey(): string {
@@ -189,10 +191,18 @@ export class ConfirmedTransactionData extends DTO.AbstractConfirmedTransactionDa
 
 	// Multi-Payment
 	public override payments(): { recipientId: string; amount: BigNumber }[] {
-		return this.data.asset.payments.map((payment: { recipientId: string; amount: BigNumber }) => ({
-			address: payment.recipientId,
-			amount: this.bigNumberService.make(payment.amount),
-		}));
+		const payments: { recipientId: string; amount: BigNumber }[] = [];
+
+		const [recipients, amounts] = decodeFunctionData(this.data.data, AbiType.MultiPayment).args;
+
+		for (const index in recipients) {
+			payments[index] = {
+				amount: formatUnits(amounts[index], "ark"),
+				recipientId: recipients[index],
+			};
+		}
+
+		return payments;
 	}
 
 	public override methodHash(): string {

--- a/packages/mainsail/source/helpers/decode-function-data.ts
+++ b/packages/mainsail/source/helpers/decode-function-data.ts
@@ -1,17 +1,27 @@
 import { decodeFunctionData as viemDecodeFunctionData, Hex } from "viem";
-import { ConsensusAbi, UsernamesAbi } from "@mainsail/evm-contracts";
+import { ConsensusAbi, UsernamesAbi, MultiPaymentAbi } from "@mainsail/evm-contracts";
 
 interface FunctionData {
 	functionName: string;
 	args: any[];
 }
 
-export const decodeFunctionData = (data: Hex, abiType: "consensus" | "username" = "consensus"): FunctionData => {
-	const abi = abiType === "consensus" ? ConsensusAbi.abi : UsernamesAbi.abi;
+export enum AbiType {
+	"Consensus" = "consensus",
+	"Username" = "username",
+	"MultiPayment" = "multiPayment",
+}
+
+export const decodeFunctionData = (data: Hex, abiType: AbiType = AbiType.Consensus): FunctionData => {
+	const abiMap: Record<AbiType, any> = {
+		[AbiType.Consensus]: ConsensusAbi.abi,
+		[AbiType.Username]: UsernamesAbi.abi,
+		[AbiType.MultiPayment]: MultiPaymentAbi.abi,
+	};
 
 	try {
 		const result = viemDecodeFunctionData({
-			abi,
+			abi: abiMap[abiType],
 			data,
 		}) as FunctionData;
 

--- a/packages/mainsail/source/signed-transaction.dto.ts
+++ b/packages/mainsail/source/signed-transaction.dto.ts
@@ -1,11 +1,11 @@
 import { Contracts, DTO, Exceptions, IoC } from "@ardenthq/sdk";
-import { MultiPaymentItem } from "@ardenthq/sdk/source/signed-transaction.dto.contract.js";
 import { BigNumber } from "@ardenthq/sdk-helpers";
 import { DateTime } from "@ardenthq/sdk-intl";
 import { Utils } from "@mainsail/crypto-transaction";
 import { Application } from "@mainsail/kernel";
 import { Hex } from "viem";
 
+import { MultiPaymentItem } from "@ardenthq/sdk/source/confirmed-transaction.dto.contract.js";
 import { BindingType } from "./coin.contract.js";
 import { Hash } from "./crypto/hash.js";
 import { AbiType, decodeFunctionData } from "./helpers/decode-function-data.js";

--- a/packages/mainsail/source/transaction-type.service.test.ts
+++ b/packages/mainsail/source/transaction-type.service.test.ts
@@ -29,7 +29,7 @@ describe("TransactionTypeService", async ({ assert, it, nock, loader }) => {
 	// });
 
 	it("should determine if the transaction is a multi payment", () => {
-		assert.true(TransactionTypeService.isMultiPayment({ data: "0x88d695b2" }));
+		assert.true(TransactionTypeService.isMultiPayment({ data: "0x084ce708" }));
 		assert.false(TransactionTypeService.isMultiPayment({ data: "0x58d695b2" }));
 	});
 

--- a/packages/mainsail/source/transaction-type.service.ts
+++ b/packages/mainsail/source/transaction-type.service.ts
@@ -4,7 +4,7 @@ import { FunctionSigs } from "@mainsail/evm-contracts";
 type TransactionData = Record<string, any>;
 
 export const TransactionTypes = {
-	MultiPayment: "0x88d695b2",
+	MultiPayment: "0x084ce708",
 	RegisterUsername: "0x36a94134",
 	ResignUsername: "0xebed6dab",
 	Transfer: "",

--- a/packages/profiles/source/signed-transaction.dto.ts
+++ b/packages/profiles/source/signed-transaction.dto.ts
@@ -4,11 +4,11 @@ import { Contracts, DTO } from "@ardenthq/sdk";
 import { BigNumber } from "@ardenthq/sdk-helpers";
 import { DateTime } from "@ardenthq/sdk-intl";
 
+import { MultiPaymentItem } from "@ardenthq/sdk/source/confirmed-transaction.dto.contract.js";
 import { container } from "./container.js";
 import { Identifiers } from "./container.models.js";
 import { IExchangeRateService, IReadWriteWallet } from "./contracts.js";
 import { ExtendedTransactionRecipient } from "./transaction.dto.js";
-import { MultiPaymentItem } from "@ardenthq/sdk/source/signed-transaction.dto.contract";
 
 export class ExtendedSignedTransactionData {
 	readonly #data: Contracts.SignedTransactionData;

--- a/packages/profiles/source/signed-transaction.dto.ts
+++ b/packages/profiles/source/signed-transaction.dto.ts
@@ -239,11 +239,11 @@ export class ExtendedSignedTransactionData {
 	}
 
 	// @ts-ignore
-	public payments(): MultiPaymentItem[] {
+	public payments(): { recipientId: string; amount: number; }[] {
 		return this.#data.payments().map((payment) => {
 			return {
-				recipientId: payment.recipientId,
 				amount: payment.amount.toHuman(),
+				recipientId: payment.recipientId,
 			}
 		});
 	}

--- a/packages/profiles/source/signed-transaction.dto.ts
+++ b/packages/profiles/source/signed-transaction.dto.ts
@@ -8,6 +8,7 @@ import { container } from "./container.js";
 import { Identifiers } from "./container.models.js";
 import { IExchangeRateService, IReadWriteWallet } from "./contracts.js";
 import { ExtendedTransactionRecipient } from "./transaction.dto.js";
+import { MultiPaymentItem } from "@ardenthq/sdk/source/signed-transaction.dto.contract";
 
 export class ExtendedSignedTransactionData {
 	readonly #data: Contracts.SignedTransactionData;
@@ -235,6 +236,16 @@ export class ExtendedSignedTransactionData {
 
 	public hash(): string {
 		return this.#data.hash();
+	}
+
+	// @ts-ignore
+	public payments(): MultiPaymentItem[] {
+		return this.#data.payments().map((payment) => {
+			return {
+				recipientId: payment.recipientId,
+				amount: payment.amount.toHuman(),
+			}
+		});
 	}
 
 	public recipients(): ExtendedTransactionRecipient[] {

--- a/packages/profiles/source/transaction.dto.ts
+++ b/packages/profiles/source/transaction.dto.ts
@@ -219,13 +219,12 @@ export class ExtendedConfirmedTransactionData implements Contracts.ConfirmedTran
 
 	// @ts-ignore
 	public payments(): { recipientId: string; amount: number }[] {
-		// @ts-ignore
-		return this.data<Contracts.ConfirmedTransactionData>()
-			.payments()
-			.map((payment: { recipientId: string; amount: BigNumber }) => ({
+		return this.data<Contracts.ConfirmedTransactionData>().payments().map((payment) => {
+			return {
 				recipientId: payment.recipientId,
 				amount: payment.amount.toHuman(),
-			}));
+			}
+		});
 	}
 
 	public publicKeys(): string[] {

--- a/packages/sdk/source/confirmed-transaction.dto.contract.ts
+++ b/packages/sdk/source/confirmed-transaction.dto.contract.ts
@@ -6,6 +6,11 @@ export interface MultiPaymentRecipient {
 	amount: BigNumber;
 }
 
+export interface MultiPaymentItem {
+	recipientId: string;
+	amount: BigNumber;
+}
+
 // These types and interfaces are responsible for transaction-specific methods.
 export type TransactionDataMeta = string | number | boolean | undefined;
 
@@ -124,7 +129,7 @@ export interface ConfirmedTransactionData {
 	hash(): string;
 
 	// Multi-Payment
-	payments(): { recipientId: string; amount: BigNumber }[];
+	payments(): MultiPaymentItem[];
 
 	methodHash(): string;
 

--- a/packages/sdk/source/signed-transaction.dto.contract.ts
+++ b/packages/sdk/source/signed-transaction.dto.contract.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "@ardenthq/sdk-helpers";
 import { DateTime } from "@ardenthq/sdk-intl";
 
-import { MultiPaymentRecipient } from "./confirmed-transaction.dto.contract.js";
+import { MultiPaymentItem, MultiPaymentRecipient } from "./confirmed-transaction.dto.contract.js";
 
 export type RawTransactionData = any;
 
@@ -68,6 +68,9 @@ export interface SignedTransactionData {
 
 	votes(): string[];
 	unvotes(): string[];
+
+	// Multi-Payment
+	payments(): MultiPaymentItem[];
 
 	// @TODO: remove those after introducing proper signed tx DTOs
 	username(): string;

--- a/packages/sdk/source/signed-transaction.dto.ts
+++ b/packages/sdk/source/signed-transaction.dto.ts
@@ -265,7 +265,7 @@ export class AbstractSignedTransactionData implements SignedTransactionData {
 
 	public recipients(): MultiPaymentRecipient[] {
 		if (this.isMultiPayment()) {
-			return this.signedData.asset.payments.map((payment: { recipientId: string; amount: BigNumber }) => ({
+			return this.signedData.payments().map((payment: { recipientId: string; amount: BigNumber }) => ({
 				address: payment.recipientId,
 				amount: this.bigNumberService.make(payment.amount),
 			}));

--- a/packages/sdk/source/signed-transaction.dto.ts
+++ b/packages/sdk/source/signed-transaction.dto.ts
@@ -5,7 +5,7 @@ import { BigNumber } from "@ardenthq/sdk-helpers";
 import { DateTime } from "@ardenthq/sdk-intl";
 import { strict as assert } from "assert";
 
-import { MultiPaymentRecipient } from "./confirmed-transaction.dto.contract.js";
+import { MultiPaymentItem, MultiPaymentRecipient } from "./confirmed-transaction.dto.contract.js";
 import { IContainer } from "./container.contracts.js";
 import { RawTransactionData, SignedTransactionData } from "./contracts.js";
 import { NotImplemented } from "./exceptions.js";
@@ -256,6 +256,11 @@ export class AbstractSignedTransactionData implements SignedTransactionData {
 
 	public hash(): string {
 		return this.signedData.asset.ipfs;
+	}
+
+	// Multi-Payment
+	public payments(): MultiPaymentItem[] {
+		throw new NotImplemented(this.constructor.name, this.payments.name);
 	}
 
 	public recipients(): MultiPaymentRecipient[] {


### PR DESCRIPTION
Closes: https://app.clickup.com/t/86dvz97hc

**Changelog:**
- updates logic for `Signed` and `Confirmed` transactions to have right `recipients`, `payment` and `amount` data 
    - adds `payments()` method for `Signed` transaction class to ensure consistency
- refactors  `decode-function-data.ts` to support multiple `abi`s
- other minor tweaks and fixes

Note: I couldn't test it with the signed transactions, but it works fine with confirmed transactions
