### PR TITLE
refactor: remove multisignature related tests

### DIFF
--- a/packages/mainsail/source/address.service.test.ts
+++ b/packages/mainsail/source/address.service.test.ts
@@ -21,16 +21,6 @@ describe("AddressService", async ({ assert, beforeEach, it, nock, loader }) => {
 		assert.equal(result, { address: identity.address, type: "bip39" });
 	});
 
-	// @TODO: fix when MultiSignature implemented
-	// it("should generate an output from a multiSignature", async (context) => {
-	// 	const result = await context.subject.fromMultiSignature({
-	// 		min: identity.multiSignature.min,
-	// 		publicKeys: identity.multiSignature.publicKeys,
-	// 	});
-	//
-	// 	assert.equal(result, { address: "DMS861mLRrtH47QUMVif3C2rBCAdHbmwsi", type: "bip39" });
-	// });
-
 	it("should generate an output from a publicKey", async (context) => {
 		const result = await context.subject.fromPublicKey(identity.publicKey);
 

--- a/packages/mainsail/source/confirmed-transaction.dto.test.ts
+++ b/packages/mainsail/source/confirmed-transaction.dto.test.ts
@@ -1,25 +1,24 @@
-import { BigNumber } from "@ardenthq/sdk-helpers";
 import { IoC } from "@ardenthq/sdk";
+import { BigNumber } from "@ardenthq/sdk-helpers";
 import { DateTime } from "@ardenthq/sdk-intl";
 import { describe } from "@ardenthq/sdk-test";
+
 import TransferFixture from "../test/fixtures/client/transfer-transaction.json";
+import UnvoteFixture from "../test/fixtures/client/unvote-transaction.json";
 import ValidatorRegistrationFixture from "../test/fixtures/client/validator-registration-transaction.json";
 import ValidatorResignationFixture from "../test/fixtures/client/validator-resignation-transaction.json";
 import VoteFixture from "../test/fixtures/client/vote-transaction.json";
-import UnvoteFixture from "../test/fixtures/client/unvote-transaction.json";
 import { createService } from "../test/mocking";
-import { ConfirmedTransactionData } from "./confirmed-transaction.dto.js";
-import { BindingType } from "./coin.contract";
 import { AddressService } from "./address.service";
+import { BindingType } from "./coin.contract";
+import { ConfirmedTransactionData } from "./confirmed-transaction.dto.js";
 import { formatUnits } from "./helpers/format-units";
 
-const createSubject = async () => {
-	return await createService(ConfirmedTransactionData, "mainsail.devnet", function (container: IoC.Container) {
+const createSubject = async () => await createService(ConfirmedTransactionData, "mainsail.devnet", function (container: IoC.Container) {
 		if (container.missing(BindingType.AddressService)) {
 			container.constant(BindingType.AddressService, new AddressService(container));
 		}
 	});
-};
 
 describe("ConfirmedTransactionData", async ({ assert, beforeEach, it, stub }) => {
 	beforeEach(async (context) => {
@@ -229,35 +228,6 @@ describe("ConfirmedTransactionData - ValidatorResignationData", ({ assert, befor
 // 		assert.is(context.subject.type(), "multiPayment");
 // 	});
 // });
-
-// @TODO: fix when MultiSignature implemented
-// describe("ConfirmedTransactionData - MultiSignatureData", ({ assert, beforeEach, it, nock, loader }) => {
-// 	beforeEach(async (context) => {
-// 		context.subject = await createService(ConfirmedTransactionData);
-// 		context.subject.configure({
-// 			asset: {
-// 				multiSignature: {
-// 					min: 1,
-// 					publicKeys: ["2", "3"],
-// 				},
-// 			},
-// 			type: 4,
-// 		});
-// 	});
-//
-// 	it("should have a list of participant public keys", (context) => {
-// 		assert.length(context.subject.publicKeys(), 2);
-// 	});
-//
-// 	it("should have a minimum number or required signatures", (context) => {
-// 		assert.is(context.subject.min(), 1);
-// 	});
-//
-// 	it("should have a type", (context) => {
-// 		assert.is(context.subject.type(), "multiSignature");
-// 	});
-// });
-//
 
 describe("ConfirmedTransactionData - VoteData", ({ assert, beforeEach, it, nock, loader }) => {
 	beforeEach(async (context) => {

--- a/packages/mainsail/source/confirmed-transaction.dto.test.ts
+++ b/packages/mainsail/source/confirmed-transaction.dto.test.ts
@@ -14,7 +14,8 @@ import { BindingType } from "./coin.contract";
 import { ConfirmedTransactionData } from "./confirmed-transaction.dto.js";
 import { formatUnits } from "./helpers/format-units";
 
-const createSubject = async () => await createService(ConfirmedTransactionData, "mainsail.devnet", function (container: IoC.Container) {
+const createSubject = async () =>
+	await createService(ConfirmedTransactionData, "mainsail.devnet", function (container: IoC.Container) {
 		if (container.missing(BindingType.AddressService)) {
 			container.constant(BindingType.AddressService, new AddressService(container));
 		}

--- a/packages/mainsail/source/public-key.service.test.ts
+++ b/packages/mainsail/source/public-key.service.test.ts
@@ -1,4 +1,5 @@
 import { describe } from "@ardenthq/sdk-test";
+
 import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { PublicKeyService } from "./public-key.service.js";
@@ -21,18 +22,8 @@ describe("PublicKeyService", async ({ assert, beforeEach, it, nock, loader }) =>
 	});
 
 	it("should fail to generate an output from an invalid mnemonic", async (context) => {
-		await assert.rejects(() => context.subject.fromMnemonic(undefined));
+		await assert.rejects(() => context.subject.fromMnemonic());
 	});
-
-	// @TODO: fix when MultiSignature implemented
-	// it("should generate an output from a multiSignature", async (context) => {
-	// 	const result = await context.subject.fromMultiSignature(
-	// 		identity.multiSignature.min,
-	// 		identity.multiSignature.publicKeys,
-	// 	);
-	//
-	// 	assert.equal(result, { publicKey: "0279f05076556da7173610a7676399c3620276ebbf8c67552ad3b1f26ec7627794" });
-	// });
 
 	it("should fail to generate an output from a multiSignature", async (context) => {
 		await assert.rejects(() => context.subject.fromMultiSignature(-1, []));
@@ -45,7 +36,7 @@ describe("PublicKeyService", async ({ assert, beforeEach, it, nock, loader }) =>
 	});
 
 	it("should fail to generate an output from a wif", async (context) => {
-		await assert.rejects(() => context.subject.fromWIF(undefined));
+		await assert.rejects(() => context.subject.fromWIF());
 	});
 
 	it("should generate an output from a secret", async (context) => {
@@ -60,6 +51,6 @@ describe("PublicKeyService", async ({ assert, beforeEach, it, nock, loader }) =>
 	});
 
 	it("should fail to generate an output from a secret", async (context) => {
-		await assert.rejects(() => context.subject.fromSecret(undefined));
+		await assert.rejects(() => context.subject.fromSecret());
 	});
 });

--- a/packages/mainsail/source/transaction-type.service.test.ts
+++ b/packages/mainsail/source/transaction-type.service.test.ts
@@ -1,4 +1,5 @@
 import { describe } from "@ardenthq/sdk-test";
+
 import { TransactionTypeService } from "./transaction-type.service.js";
 
 describe("TransactionTypeService", async ({ assert, it, nock, loader }) => {
@@ -21,12 +22,6 @@ describe("TransactionTypeService", async ({ assert, it, nock, loader }) => {
 		assert.true(TransactionTypeService.isUnvote({ data: "0x3174b689" }));
 		assert.false(TransactionTypeService.isUnvote({ data: "0x7244b689" }));
 	});
-
-	// @TODO: fix when MultiSignature implemented
-	// it("should determine if the transaction is a multi signature registration", () => {
-	// 	assert.true(TransactionTypeService.isMultiSignatureRegistration({ type: 4 }));
-	// 	assert.false(TransactionTypeService.isMultiSignatureRegistration({ type: 0 }));
-	// });
 
 	it("should determine if the transaction is a multi payment", () => {
 		assert.true(TransactionTypeService.isMultiPayment({ data: "0x084ce708" }));

--- a/packages/mainsail/source/wallet.dto.test.ts
+++ b/packages/mainsail/source/wallet.dto.test.ts
@@ -101,14 +101,5 @@ for (const network of ["devnet"]) {
 		it("should turn into a normalised object", (context) => {
 			assert.object(context.subject.toObject());
 		});
-
-		// @TODO: fix when MultiSignature implemented
-		// it("should have a multi signature asset", async () => {
-		// 	const devnetSubject = (await createService(WalletData)).fill(WalletDataFixture.devnet);
-		// 	const mainnetSubject = (await createService(WalletData)).fill(WalletDataFixture.mainnet);
-		//
-		// 	assert.throws(() => mainnetSubject.multiSignature(), "does not have");
-		// 	assert.is(devnetSubject.multiSignature(), WalletDataFixture.devnet.attributes.multiSignature);
-		// });
 	});
 }

--- a/packages/mainsail/test/fixtures/identity.ts
+++ b/packages/mainsail/test/fixtures/identity.ts
@@ -3,13 +3,6 @@ export const identity = {
 	address: "0x71c3377F6baF114A975A151c4685E600d13636F6",
 	mnemonic:
 		"proud area jazz debate clip family gift hockey mean soccer obtain naive tattoo bring keep amateur size order ozone guitar swift dash fetch stove",
-	// Multi Signature
-	// multiSignature: {
-	// 	min: 3,
-	// 	publicKeys: ["secret 1", "secret 2", "secret 3"].map((secret) => Identities.PublicKey.fromPassphrase(secret)),
-	// },
-	// multiSignatureAddress: "DMS861mLRrtH47QUMVif3C2rBCAdHbmwsi",
-	// multiSignaturePublicKey: "0279f05076556da7173610a7676399c3620276ebbf8c67552ad3b1f26ec7627794",
 	privateKey: "05fa7a8018e43636749cd012843db40ab81c929dc4a58ccf2b940188bbf261b0",
 	publicKey: "0266e0fd7186193eda55e328184fdaab9f7d4a6c867c25ef03a497fd683cae7788",
 	wif: "UX3uP3AFnFb331tBuXM1nZ1oachZAGv4mGmQRPoUkoZKF24RCF9y",


### PR DESCRIPTION
# [[test] remove multisignature and second signature related tests](https://app.clickup.com/t/86dw1338f)

## Description

- All multisignature-related tests that were commented out have been removed from the `mainsail` package.
- Only the tests about falsy assertions related to multisignature or second signature are left in the code since these are valid.
- `identity.ts` file for `mainsail` has also been updated removing all the information related to these kind of transactions.