### PR TITLE
refactor: update test coverage script

### DIFF
--- a/packages/mainsail/package.json
+++ b/packages/mainsail/package.json
@@ -21,7 +21,7 @@
 		"clean": "rimraf .coverage distribution tmp",
 		"clean:browser": "rimraf distribution/browser",
 		"test": "uvu -r tsm source .test.ts",
-		"test:coverage": "c8 pnpm run test",
+		"test:coverage": "c8 --all --reporter=text pnpm run test",
 		"test:watch": "watchlist source -- pnpm run test"
 	},
 	"dependencies": {


### PR DESCRIPTION
# [[test] enable coverage](https://app.clickup.com/t/86dw134gt)

## Description

- Script for test coverage has been refactored and now will print the correct uncovered files

> Note: I wanted to test setting up minimum percentages for test coverage, but c8 only throws the uncovered files every time I want to do this. Seems like we first need to finish covering all the files before doing this.

<img width="643" alt="image" src="https://github.com/user-attachments/assets/dcdaee17-79df-44db-b041-5b1a2580453f" />
