### PR TITLE
refactor: exclude source and types from coverage

### DIFF
--- a/packages/mainsail/.nycrc
+++ b/packages/mainsail/.nycrc
@@ -1,0 +1,3 @@
+{
+  "exclude": ["source/index.ts", "source/multi-signature.contract.ts", "source/ledger.service.types.ts", "distribution/*"]
+}


### PR DESCRIPTION
# [[test] exclude types and source files from coverage](https://app.clickup.com/t/86dw1j303)

## Description

- Depends on https://github.com/ArdentHQ/platform-sdk/pull/172
- `index.ts`, `multi-signature-contract`, `ledger.service.types.d.ts`, and all the `distribution` files have been excluded from coverage.