### PR TITLE
refactor: prevent forcing network sync on wallet creation 

### DIFF
--- a/packages/profiles/source/serialiser.test.ts
+++ b/packages/profiles/source/serialiser.test.ts
@@ -116,6 +116,7 @@ describe("WalletSerialiser", ({ beforeAll, beforeEach, assert, loader, each, noc
 		});
 
 		await context.subject.synchroniser().identity();
+
 	});
 
 	each(

--- a/packages/profiles/source/serialiser.test.ts
+++ b/packages/profiles/source/serialiser.test.ts
@@ -116,7 +116,6 @@ describe("WalletSerialiser", ({ beforeAll, beforeEach, assert, loader, each, noc
 		});
 
 		await context.subject.synchroniser().identity();
-
 	});
 
 	each(

--- a/packages/profiles/source/serialiser.test.ts
+++ b/packages/profiles/source/serialiser.test.ts
@@ -115,7 +115,7 @@ describe("WalletSerialiser", ({ beforeAll, beforeEach, assert, loader, each, noc
 			network: "ark.devnet",
 		});
 
-		await context.subject.synchroniser().identity()
+		await context.subject.synchroniser().identity();
 	});
 
 	each(
@@ -127,7 +127,6 @@ describe("WalletSerialiser", ({ beforeAll, beforeEach, assert, loader, each, noc
 			context.subject.data().set(WalletData.Balance, dataset.balance);
 			context.subject.data().set(WalletData.DerivationPath, "1");
 			context.subject.data().set(WalletFlag.Starred, true);
-
 
 			const actual = context.subject.toObject();
 

--- a/packages/profiles/source/serialiser.test.ts
+++ b/packages/profiles/source/serialiser.test.ts
@@ -114,6 +114,8 @@ describe("WalletSerialiser", ({ beforeAll, beforeEach, assert, loader, each, noc
 			mnemonic: identity.mnemonic,
 			network: "ark.devnet",
 		});
+
+		await context.subject.synchroniser().identity()
 	});
 
 	each(
@@ -125,6 +127,7 @@ describe("WalletSerialiser", ({ beforeAll, beforeEach, assert, loader, each, noc
 			context.subject.data().set(WalletData.Balance, dataset.balance);
 			context.subject.data().set(WalletData.DerivationPath, "1");
 			context.subject.data().set(WalletFlag.Starred, true);
+
 
 			const actual = context.subject.toObject();
 

--- a/packages/profiles/source/wallet-transaction.service.test.ts
+++ b/packages/profiles/source/wallet-transaction.service.test.ts
@@ -64,6 +64,8 @@ describe("ARK", ({ beforeAll, beforeEach, skip, it, nock, stub, assert, loader }
 			network: "ark.devnet",
 		});
 
+		await context.wallet.synchroniser().identity();
+
 		context.subject = new TransactionService(context.wallet);
 	});
 
@@ -126,10 +128,12 @@ describe("ARK", ({ beforeAll, beforeEach, skip, it, nock, stub, assert, loader }
 			context.wallet,
 			"citizen door athlete item name various drive onion foster audit board myself",
 		);
+
 		const identity2 = await deriveIdentity(
 			context.wallet,
 			"upset boat motor few ketchup merge punch gesture lecture piano neutral uniform",
 		);
+
 
 		const id = await context.subject.signMultiSignature({
 			data: {

--- a/packages/profiles/source/wallet-transaction.service.test.ts
+++ b/packages/profiles/source/wallet-transaction.service.test.ts
@@ -134,7 +134,6 @@ describe("ARK", ({ beforeAll, beforeEach, skip, it, nock, stub, assert, loader }
 			"upset boat motor few ketchup merge punch gesture lecture piano neutral uniform",
 		);
 
-
 		const id = await context.subject.signMultiSignature({
 			data: {
 				min: 1,

--- a/packages/profiles/source/wallet.factory.test.ts
+++ b/packages/profiles/source/wallet.factory.test.ts
@@ -66,6 +66,8 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			network: "ark.devnet",
 		});
 
+		await wallet.synchroniser().identity()
+
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
 	});
@@ -90,6 +92,7 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			password: "password",
 		});
 
+		await wallet.synchroniser().identity()
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
 		assert.string(wallet.data().get(WalletData.EncryptedSigningKey));
@@ -212,6 +215,8 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			network: "ark.devnet",
 		});
 
+		await wallet.synchroniser().identity()
+
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
 
@@ -230,6 +235,8 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			network: "ark.devnet",
 			publicKey: "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd",
 		});
+
+		await wallet.synchroniser().identity()
 
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
@@ -274,6 +281,8 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			privateKey: "e2511a6022953eb399fbd48f84619c04c894f735aee107b02a7690075ae67617",
 		});
 
+		await wallet.synchroniser().identity()
+
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
 	});
@@ -286,6 +295,8 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			path: "m/44",
 		});
 
+		await wallet.synchroniser().identity()
+
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
 	});
@@ -296,6 +307,8 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			network: "ark.devnet",
 			wif: "SHA89yQdW3bLFYyCvEBpn7ngYNR8TEojGCC1uAJjT5esJPm1NiG3",
 		});
+
+		await wallet.synchroniser().identity()
 
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
@@ -316,6 +329,8 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			password: "password",
 			wif: "6PYRydorcUPgUAtyd8KQCPd3YHo3vBAmSkBmwFcbEj7W4wBWoQ4JjxLj2d",
 		});
+
+		await wallet.synchroniser().identity()
 
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");

--- a/packages/profiles/source/wallet.factory.test.ts
+++ b/packages/profiles/source/wallet.factory.test.ts
@@ -66,7 +66,7 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			network: "ark.devnet",
 		});
 
-		await wallet.synchroniser().identity()
+		await wallet.synchroniser().identity();
 
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
@@ -92,7 +92,7 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			password: "password",
 		});
 
-		await wallet.synchroniser().identity()
+		await wallet.synchroniser().identity();
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
 		assert.string(wallet.data().get(WalletData.EncryptedSigningKey));
@@ -215,7 +215,7 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			network: "ark.devnet",
 		});
 
-		await wallet.synchroniser().identity()
+		await wallet.synchroniser().identity();
 
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
@@ -236,7 +236,7 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			publicKey: "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd",
 		});
 
-		await wallet.synchroniser().identity()
+		await wallet.synchroniser().identity();
 
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
@@ -281,7 +281,7 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			privateKey: "e2511a6022953eb399fbd48f84619c04c894f735aee107b02a7690075ae67617",
 		});
 
-		await wallet.synchroniser().identity()
+		await wallet.synchroniser().identity();
 
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
@@ -295,7 +295,7 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			path: "m/44",
 		});
 
-		await wallet.synchroniser().identity()
+		await wallet.synchroniser().identity();
 
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
@@ -308,7 +308,7 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			wif: "SHA89yQdW3bLFYyCvEBpn7ngYNR8TEojGCC1uAJjT5esJPm1NiG3",
 		});
 
-		await wallet.synchroniser().identity()
+		await wallet.synchroniser().identity();
 
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
@@ -330,7 +330,7 @@ describe("WalletFactory", ({ beforeAll, beforeEach, loader, nock, assert, stub, 
 			wif: "6PYRydorcUPgUAtyd8KQCPd3YHo3vBAmSkBmwFcbEj7W4wBWoQ4JjxLj2d",
 		});
 
-		await wallet.synchroniser().identity()
+		await wallet.synchroniser().identity();
 
 		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");

--- a/packages/profiles/source/wallet.factory.ts
+++ b/packages/profiles/source/wallet.factory.ts
@@ -112,16 +112,13 @@ export class WalletFactory implements IWalletFactory {
 	}
 
 	/** {@inheritDoc IWalletFactory.fromAddress} */
-	public async fromAddress(
-		{ coin, network, address }: IAddressOptions,
-		options?: { ttl?: number },
-	): Promise<IReadWriteWallet> {
+	public async fromAddress({ coin, network, address }: IAddressOptions): Promise<IReadWriteWallet> {
 		const wallet: IReadWriteWallet = new Wallet(UUID.random(), {}, this.#profile);
 		wallet.data().set(WalletData.ImportMethod, WalletImportMethod.Address);
 		wallet.data().set(WalletData.Status, WalletFlag.Cold);
 
 		await wallet.mutator().coin(coin, network);
-		await wallet.mutator().address({ address }, options);
+		await wallet.mutator().address({ address });
 
 		return wallet;
 	}

--- a/packages/profiles/source/wallet.mutator.ts
+++ b/packages/profiles/source/wallet.mutator.ts
@@ -78,8 +78,7 @@ export class WalletMutator implements IWalletMutator {
 	}
 
 	/** {@inheritDoc IWalletMutator.address} */
-	public async address(
-		{ address, path, type }: Partial<Services.AddressDataTransferObject>): Promise<void> {
+	public async address({ address, path, type }: Partial<Services.AddressDataTransferObject>): Promise<void> {
 		if (type) {
 			this.#wallet.data().set(WalletData.DerivationType, type);
 		}

--- a/packages/profiles/source/wallet.mutator.ts
+++ b/packages/profiles/source/wallet.mutator.ts
@@ -79,9 +79,7 @@ export class WalletMutator implements IWalletMutator {
 
 	/** {@inheritDoc IWalletMutator.address} */
 	public async address(
-		{ address, path, type }: Partial<Services.AddressDataTransferObject>,
-		options?: { ttl?: number },
-	): Promise<void> {
+		{ address, path, type }: Partial<Services.AddressDataTransferObject>): Promise<void> {
 		if (type) {
 			this.#wallet.data().set(WalletData.DerivationType, type);
 		}
@@ -93,8 +91,6 @@ export class WalletMutator implements IWalletMutator {
 		this.#wallet.data().set(WalletData.Address, address);
 
 		this.avatar(this.#wallet.address());
-
-		await this.#wallet.synchroniser().identity({ ttl: options?.ttl });
 	}
 
 	/** {@inheritDoc IWalletMutator.avatar} */

--- a/packages/profiles/source/wallet.repository.test.ts
+++ b/packages/profiles/source/wallet.repository.test.ts
@@ -36,6 +36,8 @@ const importByMnemonic = async (context, mnemonic, coin, network, bip) => {
 		network,
 	});
 
+	await wallet.synchroniser().identity();
+
 	context.subject.push(wallet);
 
 	return wallet;

--- a/packages/profiles/source/wallet.synchroniser.test.ts
+++ b/packages/profiles/source/wallet.synchroniser.test.ts
@@ -73,6 +73,8 @@ describe("WalletSynchroniser", ({ beforeAll, beforeEach, loader, nock, assert, s
 			network: "ark.devnet",
 		});
 
+		await context.wallet.synchroniser().identity()
+
 		context.actsWithMnemonic = context.actsWithMnemonic ?? stub(context.wallet, "actsWithMnemonic");
 	});
 
@@ -88,6 +90,7 @@ describe("WalletSynchroniser", ({ beforeAll, beforeEach, loader, nock, assert, s
 			password: "password",
 		});
 
+		await context.wallet.synchroniser().identity()
 		await assert.resolves(() => new WalletSynchroniser(context.wallet).coin());
 	});
 
@@ -101,6 +104,8 @@ describe("WalletSynchroniser", ({ beforeAll, beforeEach, loader, nock, assert, s
 		await context.wallet
 			.mutator()
 			.identity("nuclear anxiety mandate board property fade chief mule west despair photo fiber");
+
+		await context.wallet.synchroniser().identity()
 
 		await new WalletSynchroniser(context.wallet).multiSignature();
 

--- a/packages/profiles/source/wallet.synchroniser.test.ts
+++ b/packages/profiles/source/wallet.synchroniser.test.ts
@@ -73,7 +73,7 @@ describe("WalletSynchroniser", ({ beforeAll, beforeEach, loader, nock, assert, s
 			network: "ark.devnet",
 		});
 
-		await context.wallet.synchroniser().identity()
+		await context.wallet.synchroniser().identity();
 
 		context.actsWithMnemonic = context.actsWithMnemonic ?? stub(context.wallet, "actsWithMnemonic");
 	});
@@ -90,7 +90,7 @@ describe("WalletSynchroniser", ({ beforeAll, beforeEach, loader, nock, assert, s
 			password: "password",
 		});
 
-		await context.wallet.synchroniser().identity()
+		await context.wallet.synchroniser().identity();
 		await assert.resolves(() => new WalletSynchroniser(context.wallet).coin());
 	});
 
@@ -105,7 +105,7 @@ describe("WalletSynchroniser", ({ beforeAll, beforeEach, loader, nock, assert, s
 			.mutator()
 			.identity("nuclear anxiety mandate board property fade chief mule west despair photo fiber");
 
-		await context.wallet.synchroniser().identity()
+		await context.wallet.synchroniser().identity();
 
 		await new WalletSynchroniser(context.wallet).multiSignature();
 

--- a/packages/profiles/source/wallet.test.ts
+++ b/packages/profiles/source/wallet.test.ts
@@ -91,6 +91,8 @@ describe("Wallet", ({ beforeAll, beforeEach, loader, nock, assert, stub, it }) =
 			mnemonic: identity.mnemonic,
 			network: "ark.devnet",
 		});
+
+		await context.subject.synchroniser().identity()
 	});
 
 	// afterEach(() => jest.restoreAllMocks());
@@ -407,6 +409,8 @@ describe("Wallet", ({ beforeAll, beforeEach, loader, nock, assert, stub, it }) =
 
 		await context.subject.mutator().coin("ARK", "ark.devnet");
 		await context.subject.mutator().identity(identity.mnemonic);
+
+		await context.subject.synchroniser().identity()
 
 		assert.true(context.subject.hasSyncedWithNetwork());
 	});

--- a/packages/profiles/source/wallet.test.ts
+++ b/packages/profiles/source/wallet.test.ts
@@ -92,7 +92,7 @@ describe("Wallet", ({ beforeAll, beforeEach, loader, nock, assert, stub, it }) =
 			network: "ark.devnet",
 		});
 
-		await context.subject.synchroniser().identity()
+		await context.subject.synchroniser().identity();
 	});
 
 	// afterEach(() => jest.restoreAllMocks());
@@ -410,7 +410,7 @@ describe("Wallet", ({ beforeAll, beforeEach, loader, nock, assert, stub, it }) =
 		await context.subject.mutator().coin("ARK", "ark.devnet");
 		await context.subject.mutator().identity(identity.mnemonic);
 
-		await context.subject.synchroniser().identity()
+		await context.subject.synchroniser().identity();
 
 		assert.true(context.subject.hasSyncedWithNetwork());
 	});

--- a/packages/profiles/test/integration/musig.test.helpers.ts
+++ b/packages/profiles/test/integration/musig.test.helpers.ts
@@ -28,6 +28,8 @@ export const generateWalletsFromMnemonics = async ({
 			mnemonic,
 		});
 
+		await wallet.synchroniser().identity()
+
 		wallets.push({
 			wallet,
 			mnemonic,

--- a/packages/profiles/test/integration/musig.test.helpers.ts
+++ b/packages/profiles/test/integration/musig.test.helpers.ts
@@ -28,7 +28,7 @@ export const generateWalletsFromMnemonics = async ({
 			mnemonic,
 		});
 
-		await wallet.synchroniser().identity()
+		await wallet.synchroniser().identity();
 
 		wallets.push({
 			wallet,

--- a/packages/profiles/test/mocking.ts
+++ b/packages/profiles/test/mocking.ts
@@ -81,7 +81,7 @@ export const importByMnemonic = async (
 		network,
 	});
 
-	await wallet.synchroniser().identity()
+	await wallet.synchroniser().identity();
 
 	profile.wallets().push(wallet);
 
@@ -104,7 +104,7 @@ export const importByAddressWithDerivationPath = async (
 		path,
 	});
 
-	await wallet.synchroniser().identity()
+	await wallet.synchroniser().identity();
 
 	profile.wallets().push(wallet);
 
@@ -119,7 +119,7 @@ export const generateWallet = async (profile: IProfile, coin: string, network: s
 		network,
 	});
 
-	await wallet.synchroniser().identity()
+	await wallet.synchroniser().identity();
 
 	profile.wallets().push(wallet);
 

--- a/packages/profiles/test/mocking.ts
+++ b/packages/profiles/test/mocking.ts
@@ -81,6 +81,8 @@ export const importByMnemonic = async (
 		network,
 	});
 
+	await wallet.synchroniser().identity()
+
 	profile.wallets().push(wallet);
 
 	return wallet;
@@ -102,6 +104,8 @@ export const importByAddressWithDerivationPath = async (
 		path,
 	});
 
+	await wallet.synchroniser().identity()
+
 	profile.wallets().push(wallet);
 
 	return wallet;
@@ -114,6 +118,8 @@ export const generateWallet = async (profile: IProfile, coin: string, network: s
 		coin,
 		network,
 	});
+
+	await wallet.synchroniser().identity()
 
 	profile.wallets().push(wallet);
 


### PR DESCRIPTION
Currently when a wallet is imported it forces wallet to sync with the network which seems unecessary as the wallet.synchroniser() is already exposed and can be invoked by the caller when needed.

Fixes the issue mentioned in https://github.com/ArdentHQ/arkvault/pull/1011#pullrequestreview-2654556648
