### PR TITLE
refactor: accept transport instance as a parameter in ledger service

### DIFF
--- a/packages/mainsail/source/ledger.service.ts
+++ b/packages/mainsail/source/ledger.service.ts
@@ -3,7 +3,7 @@ import { Collections, Contracts, IoC, Services } from "@ardenthq/sdk";
 import { BIP44, HDKey } from "@ardenthq/sdk-cryptography";
 import { Exceptions } from "@mainsail/contracts";
 import { chunk, createRange, formatLedgerDerivationPath } from "./ledger.service.helpers.js";
-import { LedgerTransportFactory } from "@ardenthq/sdk/distribution/esm/ledger.contract.js";
+import { LedgerTransportInstance } from "./ledger.service.types.js";
 
 export class LedgerService extends Services.AbstractLedgerService {
 	readonly #clientService!: Services.ClientService;
@@ -22,9 +22,9 @@ export class LedgerService extends Services.AbstractLedgerService {
 		return this.disconnect();
 	}
 
-	public override async connect(transport: (transport: LedgerTransportFactory) => any): Promise<void> {
+	public override async connect(setupTransport: SetupLedgerFactory): Promise<void> {
 		this.#ledger = await this.ledgerTransportFactory();
-		this.#transport = transport?.(this.#ledger);
+		this.#transport = setupTransport?.(this.#ledger);
 	}
 
 	public override async disconnect(): Promise<void> {

--- a/packages/mainsail/source/ledger.service.ts
+++ b/packages/mainsail/source/ledger.service.ts
@@ -35,7 +35,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 
 	public override async getVersion(): Promise<string> {
 		// @TODO: fix hardcoded version.
-		return "1"
+		return "1";
 	}
 
 	public override async getPublicKey(path: string): Promise<string> {
@@ -45,7 +45,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 
 	public override async getExtendedPublicKey(path: string): Promise<string> {
 		// @TODO: revisit.
-		return this.getPublicKey(path)
+		return this.getPublicKey(path);
 	}
 
 	public override async signTransaction(path: string, payload: Buffer): Promise<string> {

--- a/packages/mainsail/source/ledger.service.ts
+++ b/packages/mainsail/source/ledger.service.ts
@@ -34,7 +34,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 	}
 
 	public override async getVersion(): Promise<string> {
-		// @TODO: fix hardcoded version.
+		// @TODO: fix hardcoded number.
 		return "1";
 	}
 

--- a/packages/mainsail/source/ledger.service.ts
+++ b/packages/mainsail/source/ledger.service.ts
@@ -3,7 +3,7 @@ import { Collections, Contracts, IoC, Services } from "@ardenthq/sdk";
 import { BIP44, HDKey } from "@ardenthq/sdk-cryptography";
 import { Exceptions } from "@mainsail/contracts";
 import { chunk, createRange, formatLedgerDerivationPath } from "./ledger.service.helpers.js";
-import { LedgerTransportInstance } from "./ledger.service.types.js";
+import { SetupLedgerFactory } from "./ledger.service.types.js";
 
 export class LedgerService extends Services.AbstractLedgerService {
 	readonly #clientService!: Services.ClientService;

--- a/packages/mainsail/source/ledger.service.types.ts
+++ b/packages/mainsail/source/ledger.service.types.ts
@@ -6,6 +6,6 @@ export interface LedgerDerivationScheme {
 	address?: number;
 }
 
-export type LedgerTransport = any
-export type LedgerTransportInstance = any
-export type SetupLedgerFactory = (transport: LedgerTransport) => LedgerTransportInstance
+export type LedgerTransport = any;
+export type LedgerTransportInstance = any;
+export type SetupLedgerFactory = (transport: LedgerTransport) => LedgerTransportInstance;

--- a/packages/mainsail/source/ledger.service.types.ts
+++ b/packages/mainsail/source/ledger.service.types.ts
@@ -5,3 +5,7 @@ export interface LedgerDerivationScheme {
 	change?: number;
 	address?: number;
 }
+
+export type LedgerTransport = any
+export type LedgerTransportInstance = any
+export type SetupLedgerFactory = (transport: LedgerTransport) => LedgerTransportInstance

--- a/packages/mainsail/source/networks/mainsail.devnet.ts
+++ b/packages/mainsail/source/networks/mainsail.devnet.ts
@@ -1,6 +1,6 @@
-import { explorer, featureFlags, importMethods, transactions } from "./shared.js";
-
 import { Networks } from "@ardenthq/sdk";
+
+import { explorer, featureFlags, importMethods, transactions } from "./shared.js";
 
 const network: Networks.NetworkManifest = {
 	coin: "Mainsail",

--- a/packages/sdk/source/ledger.contract.ts
+++ b/packages/sdk/source/ledger.contract.ts
@@ -6,7 +6,7 @@ export type LedgerTransportFactory = () => Promise<LedgerTransport>;
 export type LedgerWalletList = Record<string, WalletData>;
 
 export interface LedgerService {
-	connect(): Promise<void>;
+	connect(connect?: (transport: LedgerTransportFactory) => void): Promise<void>;
 
 	disconnect(): Promise<void>;
 

--- a/packages/sdk/source/ledger.contract.ts
+++ b/packages/sdk/source/ledger.contract.ts
@@ -5,8 +5,8 @@ export type LedgerTransportFactory = () => Promise<LedgerTransport>;
 
 export type LedgerWalletList = Record<string, WalletData>;
 
-export type LedgerTransportInstance = any
-export type SetupLedgerFactory = (transport: LedgerTransport) => LedgerTransportInstance
+export type LedgerTransportInstance = any;
+export type SetupLedgerFactory = (transport: LedgerTransport) => LedgerTransportInstance;
 
 export interface LedgerService {
 	connect(setupLedgerFactory?: SetupLedgerFactory): Promise<void>;

--- a/packages/sdk/source/ledger.contract.ts
+++ b/packages/sdk/source/ledger.contract.ts
@@ -5,8 +5,11 @@ export type LedgerTransportFactory = () => Promise<LedgerTransport>;
 
 export type LedgerWalletList = Record<string, WalletData>;
 
+export type LedgerTransportInstance = any
+export type SetupLedgerFactory = (transport: LedgerTransport) => LedgerTransportInstance
+
 export interface LedgerService {
-	connect(connect?: (transport: LedgerTransportFactory) => void): Promise<void>;
+	connect(setupLedgerFactory?: SetupLedgerFactory): Promise<void>;
 
 	disconnect(): Promise<void>;
 

--- a/packages/sdk/source/ledger.service.ts
+++ b/packages/sdk/source/ledger.service.ts
@@ -5,7 +5,7 @@ import { IContainer } from "./container.contracts.js";
 import { WalletData } from "./contracts.js";
 import { DataTransferObjectService } from "./data-transfer-object.contract.js";
 import { NotImplemented } from "./exceptions.js";
-import { LedgerService, LedgerTransportFactory, LedgerWalletList } from "./ledger.contract.js";
+import { LedgerService, LedgerTransportFactory, LedgerWalletList, SetupLedgerFactory } from "./ledger.contract.js";
 import { BindingType } from "./service-provider.contract.js";
 
 export class AbstractLedgerService implements LedgerService {
@@ -24,7 +24,7 @@ export class AbstractLedgerService implements LedgerService {
 		return this.disconnect();
 	}
 
-	public async connect(): Promise<void> {
+	public async connect(_?: SetupLedgerFactory): Promise<void> {
 		throw new NotImplemented(this.constructor.name, this.connect.name);
 	}
 


### PR DESCRIPTION
Part of https://app.clickup.com/t/86dw69x5e

When building the Mainsail package with webpack and @ledgerhq/hw-app-eth, the bundle size becomes very large, leading to deployment failures in arkvault. 

This PR refactors the ledger service to accept a `setupLedgerFactory` from the caller. This change enables arkvault to optionally include `@ledgerhq/hw-app-eth` dependency while still allowing the ledger service to maintain alignment with the existing sdk architecture.

Alternative solutions such as migrating the sdk coin packages into arkvault (see [#1037](https://github.com/ArdentHQ/arkvault/pull/1037)) were attempted as PoC, but they are too costly and introduce risks at multiple levels.