### PR TITLE
refactor: replace mainsail packages by typescript-crypto

### DIFF
--- a/packages/mainsail/package.json
+++ b/packages/mainsail/package.json
@@ -58,6 +58,7 @@
 		"lodash.get": "^4.4.2",
 		"lodash.set": "^4.3.2",
 		"node-dotify": "^1.1.0",
+		"typescript-crypto": "link:../../../typescript-crypto",
 		"viem": "^2.21.51"
 	},
 	"devDependencies": {

--- a/packages/mainsail/source/address.service.ts
+++ b/packages/mainsail/source/address.service.ts
@@ -1,39 +1,11 @@
-import { Application } from "@mainsail/kernel";
-import { strict as assert } from "assert";
-import { Contracts, Identifiers } from "@mainsail/contracts";
 import { IoC, Services } from "@ardenthq/sdk";
 import { BIP39 } from "@ardenthq/sdk-cryptography";
 import { abort_if, abort_unless } from "@ardenthq/sdk-helpers";
-import { BindingType } from "./coin.contract.js";
+import { Address, PublicKey } from "typescript-crypto";
 
 export class AddressService extends Services.AbstractAddressService {
-	readonly #app: Application;
-	readonly #addressFactory: Contracts.Crypto.AddressFactory;
-	readonly #publicKeyFactory: Contracts.Crypto.PublicKeyFactory;
-	readonly #keyPairFactory: Contracts.Crypto.KeyPairFactory;
-
 	public constructor(container: IoC.IContainer) {
 		super(container);
-
-		this.#app = container.get(BindingType.Application);
-
-		this.#addressFactory = this.#app.getTagged<Contracts.Crypto.AddressFactory>(
-			Identifiers.Cryptography.Identity.Address.Factory,
-			"type",
-			"wallet",
-		);
-
-		this.#publicKeyFactory = this.#app.getTagged<Contracts.Crypto.PublicKeyFactory>(
-			Identifiers.Cryptography.Identity.PublicKey.Factory,
-			"type",
-			"wallet",
-		);
-
-		this.#keyPairFactory = this.#app.getTagged<Contracts.Crypto.KeyPairFactory>(
-			Identifiers.Cryptography.Identity.KeyPair.Factory,
-			"type",
-			"wallet",
-		);
 	}
 
 	public override async fromMnemonic(
@@ -43,20 +15,7 @@ export class AddressService extends Services.AbstractAddressService {
 		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		return {
-			address: await this.#addressFactory.fromMnemonic(mnemonic),
-			type: "bip39",
-		};
-	}
-
-	public override async fromMultiSignature({
-		min,
-		publicKeys,
-	}: Services.MultisignatureAddressInput): Promise<Services.AddressDataTransferObject> {
-		assert.ok(publicKeys);
-		assert.ok(min);
-
-		return {
-			address: await this.#addressFactory.fromMultiSignatureAsset({ min, publicKeys }),
+			address: Address.fromPassphrase(mnemonic),
 			type: "bip39",
 		};
 	}
@@ -66,7 +25,7 @@ export class AddressService extends Services.AbstractAddressService {
 		options?: Services.IdentityOptions,
 	): Promise<Services.AddressDataTransferObject> {
 		return {
-			address: await this.#addressFactory.fromPublicKey(publicKey),
+			address: Address.fromPublicKey(publicKey),
 			type: "bip39",
 		};
 	}
@@ -75,10 +34,8 @@ export class AddressService extends Services.AbstractAddressService {
 		privateKey: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.AddressDataTransferObject> {
-		const keyPair = await this.#keyPairFactory.fromPrivateKey(Buffer.from(privateKey, "hex"));
-
 		return {
-			address: await this.#addressFactory.fromPrivateKey(keyPair),
+			address: Address.fromPrivateKey(privateKey),
 			type: "bip39",
 		};
 	}
@@ -86,22 +43,14 @@ export class AddressService extends Services.AbstractAddressService {
 	public override async fromSecret(secret: string): Promise<Services.AddressDataTransferObject> {
 		abort_if(BIP39.compatible(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
 
-		const publicKey = await this.#publicKeyFactory.fromMnemonic(secret);
-
+		const publicKey = PublicKey.fromPassphrase(secret);
 		return {
-			address: await this.#addressFactory.fromPublicKey(publicKey),
-			type: "bip39",
-		};
-	}
-
-	public override async fromWIF(wif: string): Promise<Services.AddressDataTransferObject> {
-		return {
-			address: await this.#addressFactory.fromWIF(wif),
+			address: Address.fromPublicKey(publicKey.publicKey),
 			type: "bip39",
 		};
 	}
 
 	public override async validate(address: string): Promise<boolean> {
-		return await this.#addressFactory.validate(address);
+		return Address.validate(address);
 	}
 }

--- a/packages/mainsail/source/address.service.ts
+++ b/packages/mainsail/source/address.service.ts
@@ -1,17 +1,15 @@
-import { IoC, Services } from "@ardenthq/sdk";
-import { BIP39 } from "@ardenthq/sdk-cryptography";
-import { abort_if, abort_unless } from "@ardenthq/sdk-helpers";
 import { Address, PublicKey } from "typescript-crypto";
+import { abort_if, abort_unless } from "@ardenthq/sdk-helpers";
 
-export class AddressService extends Services.AbstractAddressService {
-	public constructor(container: IoC.IContainer) {
-		super(container);
+import { BIP39 } from "@ardenthq/sdk-cryptography";
+import { Services } from "@ardenthq/sdk";
+
+export class AddressService {
+	public constructor() {
+		//
 	}
 
-	public override async fromMnemonic(
-		mnemonic: string,
-		options?: Services.IdentityOptions,
-	): Promise<Services.AddressDataTransferObject> {
+	public fromMnemonic(mnemonic: string): Services.AddressDataTransferObject {
 		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		return {
@@ -20,27 +18,21 @@ export class AddressService extends Services.AbstractAddressService {
 		};
 	}
 
-	public override async fromPublicKey(
-		publicKey: string,
-		options?: Services.IdentityOptions,
-	): Promise<Services.AddressDataTransferObject> {
+	public fromPublicKey(publicKey: string): Services.AddressDataTransferObject {
 		return {
 			address: Address.fromPublicKey(publicKey),
 			type: "bip39",
 		};
 	}
 
-	public override async fromPrivateKey(
-		privateKey: string,
-		options?: Services.IdentityOptions,
-	): Promise<Services.AddressDataTransferObject> {
+	public fromPrivateKey(privateKey: string): Services.AddressDataTransferObject {
 		return {
 			address: Address.fromPrivateKey(privateKey),
 			type: "bip39",
 		};
 	}
 
-	public override async fromSecret(secret: string): Promise<Services.AddressDataTransferObject> {
+	public fromSecret(secret: string): Services.AddressDataTransferObject {
 		abort_if(BIP39.compatible(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
 
 		const publicKey = PublicKey.fromPassphrase(secret);
@@ -50,7 +42,7 @@ export class AddressService extends Services.AbstractAddressService {
 		};
 	}
 
-	public override async validate(address: string): Promise<boolean> {
+	public validate(address: string): boolean {
 		return Address.validate(address);
 	}
 }

--- a/packages/mainsail/source/ledger.service.ts
+++ b/packages/mainsail/source/ledger.service.ts
@@ -4,10 +4,11 @@ import { BIP44, HDKey } from "@ardenthq/sdk-cryptography";
 import { Exceptions } from "@mainsail/contracts";
 import { chunk, createRange, formatLedgerDerivationPath } from "./ledger.service.helpers.js";
 import { SetupLedgerFactory } from "./ledger.service.types.js";
+import { AddressService } from "./address.service.js";
 
 export class LedgerService extends Services.AbstractLedgerService {
 	readonly #clientService!: Services.ClientService;
-	readonly #addressService!: Services.AddressService;
+	readonly #addressService!: AddressService;
 	#ledger!: Services.LedgerTransport;
 	#transport!: any;
 
@@ -15,7 +16,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 		super(container);
 
 		this.#clientService = container.get(IoC.BindingType.ClientService);
-		this.#addressService = container.get(IoC.BindingType.AddressService);
+		this.#addressService = new AddressService();
 	}
 
 	public override async onPreDestroy(): Promise<void> {
@@ -94,7 +95,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 					.derive(`m/0/${addressIndex}`)
 					.publicKey.toString("hex");
 
-				const { address } = await this.#addressService.fromPublicKey(publicKey);
+				const { address } = this.#addressService.fromPublicKey(publicKey);
 
 				addresses.push(address);
 

--- a/packages/mainsail/source/transaction.service.test.ts
+++ b/packages/mainsail/source/transaction.service.test.ts
@@ -1,13 +1,7 @@
 import { IoC, Services, Signatories } from "@ardenthq/sdk";
-import { describe } from "@ardenthq/sdk-test";
 
-import { createService } from "../test/mocking";
-import { identity } from "../test/wallets";
-import { AddressService } from "./address.service.js";
 import { ClientService } from "./client.service.js";
 import { ConfirmedTransactionData } from "./confirmed-transaction.dto.js";
-import { formatUnits } from "./helpers/format-units.js";
-import { parseUnits } from "./helpers/parse-units.js";
 import { KeyPairService } from "./key-pair.service.js";
 import { LedgerService } from "./ledger.service.js";
 import { MultiSignatureService } from "./multi-signature.service.js";
@@ -16,6 +10,11 @@ import { PublicKeyService } from "./public-key.service.js";
 import { SignedTransactionData } from "./signed-transaction.dto.js";
 import { TransactionService } from "./transaction.service.js";
 import { WalletData } from "./wallet.dto.js";
+import { createService } from "../test/mocking";
+import { describe } from "@ardenthq/sdk-test";
+import { formatUnits } from "./helpers/format-units.js";
+import { identity } from "../test/wallets";
+import { parseUnits } from "./helpers/parse-units.js";
 
 describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) => {
 	beforeAll(async (context) => {
@@ -28,7 +27,6 @@ describe("TransactionService", async ({ assert, beforeAll, nock, it, loader }) =
 				WalletData,
 			});
 			container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
-			container.singleton(IoC.BindingType.AddressService, AddressService);
 			container.singleton(IoC.BindingType.ClientService, ClientService);
 			container.singleton(IoC.BindingType.KeyPairService, KeyPairService);
 			container.constant(IoC.BindingType.LedgerTransportFactory, async () => {});

--- a/packages/mainsail/source/transaction.service.ts
+++ b/packages/mainsail/source/transaction.service.ts
@@ -339,25 +339,11 @@ export class TransactionService extends Services.AbstractTransactionService {
 			publicKey = (await this.#publicKeyService.fromSecret(input.signatory.signingKey())).publicKey;
 		}
 
-		if (input.signatory.actsWithWIF() || input.signatory.actsWithConfirmationWIF()) {
-			address = (await this.#addressService.fromWIF(input.signatory.signingKey())).address;
-			publicKey = (await this.#publicKeyService.fromWIF(input.signatory.signingKey())).publicKey;
-		}
-
 		if (input.signatory.actsWithLedger()) {
 			await this.#ledgerService.connect();
 
 			publicKey = await this.#ledgerService.getPublicKey(input.signatory.signingKey());
 			address = (await this.#addressService.fromPublicKey(publicKey)).address;
-		}
-
-		if (input.signatory.actsWithMultiSignature()) {
-			address = (
-				await this.#addressService.fromMultiSignature({
-					min: input.signatory.asset().min,
-					publicKeys: input.signatory.asset().publicKeys,
-				})
-			).address;
 		}
 
 		return { address, publicKey };


### PR DESCRIPTION
replaces certain mainsail logic by the equivalent of the `typescript-crypto` package.

TODO:
- [ ] make proper `typescript-crypto` package release
- [ ] replace other areas
- [ ] slowly move away from containers