### PR TITLE
refactor: improve ledger public key reading 

### DIFF
--- a/packages/ark/source/ledger.service.ts
+++ b/packages/ark/source/ledger.service.ts
@@ -56,6 +56,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 	public override async scan(options?: {
 		useLegacy: boolean;
 		startPath?: string;
+		pageSize?: number;
 		onProgress?: (wallet: Contracts.WalletData) => void;
 	}): Promise<Services.LedgerWalletList> {
 		const pageSize = 5;

--- a/packages/mainsail/source/ledger.service.ts
+++ b/packages/mainsail/source/ledger.service.ts
@@ -20,7 +20,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 		return path.split("/").slice(-2).join("/");
 	}
 
-	async #getPublicKeys(path: string): Promise<{ extendedPublicKey: string, publicKey: string }> {
+	async #getPublicKeys(path: string): Promise<{ extendedPublicKey: string; publicKey: string }> {
 		const derivationPath = `m/${this.#extractAddressIndexFromPath(path)}`;
 		const extendedPublicKey = await this.getExtendedPublicKey(path);
 
@@ -28,7 +28,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 			.derive(derivationPath)
 			.publicKey.toString("hex");
 
-		return { extendedPublicKey, publicKey }
+		return { extendedPublicKey, publicKey };
 	}
 
 	public constructor(container: IoC.IContainer) {
@@ -109,7 +109,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 	public override async scan(options?: {
 		useLegacy: boolean;
 		startPath?: string;
-		pageSize?: number
+		pageSize?: number;
 		onProgress?: (wallet: Contracts.WalletData) => void;
 	}): Promise<Services.LedgerWalletList> {
 		const pageSize = 5;

--- a/packages/mainsail/source/ledger.service.ts
+++ b/packages/mainsail/source/ledger.service.ts
@@ -90,7 +90,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 	}
 
 	public override async getExtendedPublicKey(path: string): Promise<string> {
-		return this.#getExtendedPublicKeyWithRetry(path, 0)
+		return this.#getExtendedPublicKeyWithRetry(path);
 	}
 
 	public override async sign(path: string, serialized: string | Buffer): Promise<LedgerSignature> {

--- a/packages/mainsail/source/ledger.service.ts
+++ b/packages/mainsail/source/ledger.service.ts
@@ -38,7 +38,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 		} catch (error) {
 			if (error?.message?.includes?.("busy") && retryCount < 3) {
 				await new Promise(resolve => setTimeout(resolve, 500));
-				return await this.getExtendedPublicKey(path, retryCount + 1);
+				return await this.#getExtendedPublicKeyWithRetry(path, retryCount + 1);
 			}
 			throw new Error(error);
 		}

--- a/packages/mainsail/source/ledger.service.ts
+++ b/packages/mainsail/source/ledger.service.ts
@@ -37,7 +37,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 			return result.publicKey;
 		} catch (error) {
 			if (error?.message?.includes?.("busy") && retryCount < 3) {
-				await new Promise(resolve => setTimeout(resolve, 500));
+				await new Promise((resolve) => setTimeout(resolve, 500));
 				return await this.#getExtendedPublicKeyWithRetry(path, retryCount + 1);
 			}
 			throw new Error(error);

--- a/packages/mainsail/source/ledger.service.ts
+++ b/packages/mainsail/source/ledger.service.ts
@@ -21,8 +21,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 	}
 
 	async #getPublicKeys(path: string): Promise<{ extendedPublicKey: string; publicKey: string }> {
-		const derivationPath = `m/${this.#extractAddressIndexFromPath(path)}`;
 		const extendedPublicKey = await this.getExtendedPublicKey(path);
+		const derivationPath = `m/${this.#extractAddressIndexFromPath(path)}`;
 
 		const publicKey: string = HDKey.fromCompressedPublicKey(extendedPublicKey)
 			.derive(derivationPath)

--- a/packages/sdk/source/ledger.contract.ts
+++ b/packages/sdk/source/ledger.contract.ts
@@ -29,6 +29,7 @@ export interface LedgerService {
 	scan(options?: {
 		useLegacy: boolean;
 		startPath?: string;
+		pageSize?: number;
 		onProgress?: (wallet: WalletData) => void;
 	}): Promise<Record<string, WalletData>>;
 


### PR DESCRIPTION
* Expose `pageSize` prop on ledger scan method
* Improve performance on public key reading
* Retry public key fetch on "device busy" error

Additional fixes for https://app.clickup.com/t/86dw8fv7z
Required by https://github.com/ArdentHQ/arkvault/pull/1100