### PR TITLE
refactor: add 2nd signature method for Mainsail

### DIFF
--- a/packages/mainsail/source/wallet.dto.ts
+++ b/packages/mainsail/source/wallet.dto.ts
@@ -84,6 +84,10 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		return !!this.#getProperty(["multiSignature", "attributes.multiSignature"]);
 	}
 
+	public override isSecondSignature(): boolean {
+		return !!this.#getProperty(["secondPublicKey", "attributes.secondPublicKey"]);
+	}
+
 	#getProperty<T>(keys: string[]): T | undefined {
 		for (const key of keys) {
 			if (has(this.data, key)) {


### PR DESCRIPTION
As a part of: https://app.clickup.com/t/86dw69rr1

This PR adds a `isSecondSignature` for `Mainsail` network. For more info please see: https://helloardent.slack.com/archives/C07QTEQJK5K/p1744156811607099?thread_ts=1744123692.471109&cid=C07QTEQJK5K