### PR TITLE
refactor: sync profile wallets for given network

### DIFF
--- a/packages/mainsail/source/networks/mainsail.mainnet.ts
+++ b/packages/mainsail/source/networks/mainsail.mainnet.ts
@@ -22,7 +22,7 @@ const network: Networks.NetworkManifest = {
 	},
 	hosts: [
 		{
-			host: "https://mwallets-evm.mainsailhq.com/api",
+			host: "https://dwallets-evm.mainsailhq.com/api",
 			type: "full",
 		},
 		{

--- a/packages/mainsail/source/networks/mainsail.mainnet.ts
+++ b/packages/mainsail/source/networks/mainsail.mainnet.ts
@@ -22,7 +22,7 @@ const network: Networks.NetworkManifest = {
 	},
 	hosts: [
 		{
-			host: "https://dwallets-evm.mainsailhq.com/api",
+			host: "https://mwallets-evm.mainsailhq.com/api",
 			type: "full",
 		},
 		{

--- a/packages/profiles/source/wallet.service.ts
+++ b/packages/profiles/source/wallet.service.ts
@@ -3,11 +3,14 @@ import { pqueueSettled } from "./helpers/queue.js";
 
 export class WalletService implements IWalletService {
 	/** {@inheritDoc IWalletService.syncByProfile} */
-	public async syncByProfile(profile: IProfile): Promise<void> {
+	public async syncByProfile(profile: IProfile, networkIds?: string[]): Promise<void> {
 		const availableNetworkIds = new Set(
 			profile
 				.availableNetworks()
-				.filter((network) => network.meta().enabled === undefined || network.meta().enabled === true)
+				.filter((network) => {
+					return (network.meta().enabled === undefined || network.meta().enabled === true)
+						&& (!networkIds || networkIds?.includes(network.id()));
+				})
 				.map((network) => network.id()),
 		);
 


### PR DESCRIPTION
As a part of: https://app.clickup.com/t/86dwfh8f6

This PR adjusts `syncByProfile` call to ensure that it syncs wallets for the given networks when defined.