### PR TITLE
fix: resolve coin lookup by id instead of symbol in coingecko

### DIFF
--- a/packages/markets/source/drivers/coingecko/index.ts
+++ b/packages/markets/source/drivers/coingecko/index.ts
@@ -152,7 +152,7 @@ export class CoinGecko implements PriceTracker {
 
 		for (const value of Object.values(body)) {
 			// @ts-ignore
-			this.tokenLookup[value.symbol.toUpperCase()] = value.id;
+			this.tokenLookup[value.id.toUpperCase()] = value.id;
 		}
 
 		return this.tokenLookup[token.toUpperCase()];


### PR DESCRIPTION
Closes https://app.clickup.com/t/2570579/86e258m9x 
